### PR TITLE
Add options and improve existent

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ eight_points_guzzle:
 
         ...
 ```
-All these settings are optional.
+Allowed options: headers, allow_redirects, auth, query, curl, cert, connect_timeout, debug, decode_content, delay, form_params, multipart, sink, http_errors, expect, ssl_key, stream, synchronous, timeout, verify, cookies, proxy, version. All these settings are optional.  
+Description for all options and examples of parameters can be found [here][4].
 
 Using services in controller (eight_points_guzzle.client.**api_crm** represents the client name of the yaml config and is an instance of GuzzleHttp\Client):
 ``` php
@@ -119,8 +120,8 @@ new EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundle([
 ```
 
 ### Known and Supported Plugins
-- [gregurco/GuzzleBundleWssePlugin][4]
-- [gregurco/GuzzleBundleCachePlugin][5]
+- [gregurco/GuzzleBundleWssePlugin][5]
+- [gregurco/GuzzleBundleCachePlugin][6]
 
 ----
 
@@ -162,7 +163,7 @@ services:
 ## Contributing
 👍 If you would like to contribute to the project, please read the [CONTRIBUTING.md](CONTRIBUTING.md).
 
-🎉 Thanks to the [contributors][6] who participated in this project.
+🎉 Thanks to the [contributors][7] who participated in this project.
 
 ----
 
@@ -173,6 +174,7 @@ This bundle is released under the [MIT license](src/Resources/meta/LICENSE)
 [1]: http://guzzlephp.org/
 [2]: http://semver.org/
 [3]: https://packagist.org/packages/eightpoints/guzzle-bundle
-[4]: https://github.com/gregurco/GuzzleBundleWssePlugin
-[5]: https://github.com/gregurco/GuzzleBundleCachePlugin
-[6]: https://github.com/8p/GuzzleBundle/graphs/contributors
+[4]: http://docs.guzzlephp.org/en/latest/request-options.html
+[5]: https://github.com/gregurco/GuzzleBundleWssePlugin
+[6]: https://github.com/gregurco/GuzzleBundleCachePlugin
+[7]: https://github.com/8p/GuzzleBundle/graphs/contributors

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -44,8 +44,9 @@ class Configuration implements ConfigurationInterface
      * @version 1.0
      * @since   2013-10
      *
-     * @return  TreeBuilder
      * @throws  \RuntimeException
+     *
+     * @return  TreeBuilder
      */
     public function getConfigTreeBuilder() : TreeBuilder
     {
@@ -65,27 +66,29 @@ class Configuration implements ConfigurationInterface
      *
      * @since  2015-07
      *
-     * @return \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
-     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
      * @throws \RuntimeException
+     *
+     * @return ArrayNodeDefinition
      */
-    private function createClientsNode()
+    private function createClientsNode() : ArrayNodeDefinition
     {
         $builder = new TreeBuilder();
         $node    = $builder->root('clients');
-
-        // Filtering function to cast scalar values to boolean
-        $boolFilter = function ($value) {
-            return (bool)$value;
-        };
 
         $nodeChildren = $node->useAttributeAsKey('name')
             ->prototype('array')
                 ->children();
 
         $nodeChildren->scalarNode('class')->defaultValue('%eight_points_guzzle.http_client.class%')->end()
-                    ->scalarNode('base_url')->defaultValue(null)->end()
-
+                    ->scalarNode('base_url')
+                        ->defaultValue(null)
+                        ->validate()
+                            ->ifTrue(function ($v) {
+                                return !is_string($v);
+                            })
+                            ->thenInvalid('base_url can be: string')
+                        ->end()
+                    ->end()
                     ->arrayNode('options')
                         ->children()
                             ->arrayNode('headers')
@@ -93,12 +96,28 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('scalar')
                                 ->end()
                             ->end()
-                            ->arrayNode('auth')
-                                ->prototype('scalar')
+                            ->variableNode('allow_redirects')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_array($v) && !is_bool($v);
+                                    })
+                                    ->thenInvalid('allow_redirects can be: bool or array')
                                 ->end()
                             ->end()
-                            ->arrayNode('query')
-                                ->prototype('scalar')
+                            ->variableNode('auth')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_array($v) && !is_string($v);
+                                    })
+                                    ->thenInvalid('auth can be: string or array')
+                                ->end()
+                            ->end()
+                            ->variableNode('query')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_string($v) && !is_array($v);
+                                    })
+                                    ->thenInvalid('query can be: string or array')
                                 ->end()
                             ->end()
                             ->arrayNode('curl')
@@ -131,51 +150,67 @@ class Configuration implements ConfigurationInterface
                             ->variableNode('cert')
                                 ->validate()
                                     ->ifTrue(function ($v) {
-                                        return !is_string($v) && (!is_array($v) || count($v) != 2);
+                                        return !is_string($v) && (!is_array($v) || count($v) !== 2);
                                     })
-                                    ->thenInvalid('A string or a two entries array required')
+                                    ->thenInvalid('cert can be: string or array with two entries (path and password)')
                                 ->end()
                             ->end()
-                            ->scalarNode('connect_timeout')->end()
-                            ->booleanNode('debug')
-                                ->beforeNormalization()
-                                    ->ifString()->then($boolFilter)
+                            ->floatNode('connect_timeout')->end()
+                            ->booleanNode('debug')->end()
+                            ->variableNode('decode_content')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_string($v) && !is_bool($v);
+                                    })
+                                    ->thenInvalid('decode_content can be: bool or string (gzip, compress, deflate, etc...)')
                                 ->end()
                             ->end()
-                            ->booleanNode('decode_content')
-                                ->beforeNormalization()
-                                    ->ifString()->then($boolFilter)
+                            ->floatNode('delay')->end()
+                            ->arrayNode('form_params')
+                                ->prototype('variable')
                                 ->end()
                             ->end()
-                            ->scalarNode('delay')->end()
-                            ->booleanNode('http_errors')
-                                ->beforeNormalization()
-                                    ->ifString()->then($boolFilter)
+                            ->arrayNode('multipart')
+                                ->prototype('variable')
                                 ->end()
                             ->end()
-                            ->scalarNode('expect')->end()
-                            ->scalarNode('ssl_key')->end()
-                            ->booleanNode('stream')
-                                ->beforeNormalization()
-                                    ->ifString()->then($boolFilter)
+                            ->scalarNode('sink')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_string($v);
+                                    })
+                                    ->thenInvalid('sink can be: string')
                                 ->end()
                             ->end()
-                            ->booleanNode('synchronous')
-                                ->beforeNormalization()
-                                    ->ifString()->then($boolFilter)
+                            ->booleanNode('http_errors')->end()
+                            ->variableNode('expect')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_bool($v) && !is_int($v);
+                                    })
+                                    ->thenInvalid('expect can be: bool or int')
                                 ->end()
                             ->end()
-                            ->scalarNode('timeout')->end()
-                            ->booleanNode('verify')
-                                ->beforeNormalization()
-                                    ->ifString()->then($boolFilter)
+                            ->variableNode('ssl_key')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_string($v) && (!is_array($v) || count($v) !== 2);
+                                    })
+                                    ->thenInvalid('ssl_key can be: string or array with two entries (path and password)')
                                 ->end()
                             ->end()
-                            ->booleanNode('cookies')
-                                ->beforeNormalization()
-                                    ->ifString()->then($boolFilter)
+                            ->booleanNode('stream')->end()
+                            ->booleanNode('synchronous')->end()
+                            ->floatNode('timeout')->end()
+                            ->variableNode('verify')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_bool($v) && !is_string($v);
+                                    })
+                                    ->thenInvalid('verify can be: bool or string')
                                 ->end()
                             ->end()
+                            ->booleanNode('cookies')->end()
                             ->arrayNode('proxy')
                                 ->beforeNormalization()
                                 ->ifString()
@@ -197,7 +232,14 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                             ->end()
-                            ->scalarNode('version')->end()
+                            ->scalarNode('version')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_string($v) && !is_float($v);
+                                    })
+                                    ->thenInvalid('version can be: string or float')
+                                ->end()
+                            ->end()
                         ->end()
                     ->end();
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -46,7 +46,7 @@ class Configuration implements ConfigurationInterface
      *
      * @throws  \RuntimeException
      *
-     * @return  TreeBuilder
+     * @return  \Symfony\Component\Config\Definition\Builder\TreeBuilder
      */
     public function getConfigTreeBuilder() : TreeBuilder
     {
@@ -68,7 +68,7 @@ class Configuration implements ConfigurationInterface
      *
      * @throws \RuntimeException
      *
-     * @return ArrayNodeDefinition
+     * @return \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
      */
     private function createClientsNode() : ArrayNodeDefinition
     {

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -260,9 +260,9 @@ class ConfigurationTest extends TestCase
      * @dataProvider provideValidOptionValues
      *
      * @param array $options
-     * @param null $expects
+     * @param null|array $expects
      */
-    public function testValidOptions(array $options, $expects = null)
+    public function testValidOptions(array $options, array $expects = null)
     {
         $config = [
             'eight_points_guzzle' => [

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -31,6 +31,8 @@ class ConfigurationTest extends TestCase
                             'query' => [],
                             'curl' => [],
                             'cert' => 'path/to/cert',
+                            'form_params' => [],
+                            'multipart' => [],
                             'connect_timeout' => 5,
                             'debug' => false,
                             'decode_content' => true,
@@ -47,7 +49,7 @@ class ConfigurationTest extends TestCase
                                 'https' => 'https://proxy.org',
                                 'no' => ['host.com', 'host.org']
                             ],
-                            'version' => '1.1'
+                            'version' => '1.1',
                         ],
                         'plugin' => [],
 						'class' => '%eight_points_guzzle_bundle.http_client.class%',
@@ -83,6 +85,8 @@ class ConfigurationTest extends TestCase
                                 'path/to/cert',
                                 'password'
                             ],
+                            'form_params' => [],
+                            'multipart' => [],
                             'connect_timeout' => 5,
                             'debug' => false,
                             'decode_content' => true,
@@ -94,7 +98,7 @@ class ConfigurationTest extends TestCase
                             'synchronous' => true,
                             'timeout' => 30,
                             'verify' => true,
-                            'version' => '1.1'
+                            'version' => '1.1',
                         ],
                         'plugin' => [],
 						'class' => '%eight_points_guzzle_bundle.http_client.class%',
@@ -155,7 +159,9 @@ class ConfigurationTest extends TestCase
                             ],
                             'query' => [],
                             'curl' => [],
-                            'proxy' => 'http://proxy.org'
+                            'proxy' => 'http://proxy.org',
+                            'form_params' => [],
+                            'multipart' => [],
                         ],
                         'plugin' => [],
 						'class' => '%eight_points_guzzle_bundle.http_client.class%',
@@ -248,5 +254,138 @@ class ConfigurationTest extends TestCase
 
         $processor = new Processor();
         $processor->processConfiguration(new Configuration('eight_points_guzzle'), $config);
+    }
+
+    /**
+     * @dataProvider provideValidOptionValues
+     *
+     * @param array $options
+     * @param null $expects
+     */
+    public function testValidOptions(array $options, $expects = null)
+    {
+        $config = [
+            'eight_points_guzzle' => [
+                'clients' => [
+                    'test_client' => [
+                        'options' => $options
+                    ]
+                ]
+            ]
+        ];
+
+        $processor = new Processor();
+        $processedConfig = $processor->processConfiguration(new Configuration('eight_points_guzzle'), $config);
+
+        foreach ($options as $key => $value) {
+            $this->assertArrayHasKey($key, $processedConfig['clients']['test_client']['options']);
+            $this->assertEquals($expects !== null ? $expects[$key] : $value, $processedConfig['clients']['test_client']['options'][$key]);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function provideValidOptionValues() : array
+    {
+        return [
+            'allow_redirects is bool' => [[
+                'allow_redirects' => true,
+            ]],
+            'allow_redirects is array' => [[
+                'allow_redirects' => [
+                    'max'  => 5,
+                ],
+            ]],
+            'auth is string' => [[
+                'auth' => 'oauth',
+            ]],
+            'auth is array' => [[
+                'auth' => ['acme', 'pa55w0rd'],
+            ]],
+            'query is string' => [[
+                'query' => 'abc=123',
+            ]],
+            'query is array' => [[
+                'query' => ['foo' => 'bar'],
+            ]],
+            'cert is string' => [[
+                'cert' => '/path/server.pem',
+            ]],
+            'cert is array' => [[
+                'cert' => ['/path/server.pem', 'password'],
+            ]],
+            'connect_timeout is float' => [[
+                'connect_timeout' => 3.14,
+            ]],
+            'decode_content is boolean' => [[
+                'decode_content' => true,
+            ]],
+            'decode_content is string' => [[
+                'decode_content' => 'gzip',
+            ]],
+            'delay is float' => [[
+                'delay' => 3.14,
+            ]],
+            'form_params is array' => [[
+                'form_params' => [
+                    'foo' => 'bar',
+                    'baz' => ['hi', 'there!']
+                ],
+            ]],
+            'multipart is array' => [[
+                'multipart' => [[
+                    'name'     => 'foo',
+                    'contents' => 'data',
+                    'headers'  => ['X-Baz' => 'bar']
+                ]],
+            ]],
+            'sink is string' => [[
+                'sink' => '/path/to/file',
+            ]],
+            'http_errors is bool' => [[
+                'http_errors' => false,
+            ]],
+            'ssl_key is string' => [[
+                'cert' => '/path/server.pem',
+            ]],
+            'ssl_key is array' => [[
+                'cert' => ['/path/server.pem', 'password'],
+            ]],
+            'stream is bool' => [[
+                'stream' => true,
+            ]],
+            'synchronous is bool' => [[
+                'synchronous' => true,
+            ]],
+            'timeout is float' => [[
+                'timeout' => 3.14,
+            ]],
+            'verify is bool' => [[
+                'verify' => true,
+            ]],
+            'verify is string' => [[
+                'verify' => '/path/to/cert.pem',
+            ]],
+            'cookies is bool' => [[
+                'cookies' => true,
+            ]],
+            'proxy is string' => [
+                'options' => ['proxy' => 'tcp://localhost:8125'],
+                'expected result' => ['proxy' => ['http' => 'tcp://localhost:8125']],
+            ],
+            'proxy is array' => [[
+                'proxy' => [
+                    'http'  => 'tcp://localhost:8125',
+                    'no' => ['.mit.edu', 'foo.com'],
+                ],
+            ]],
+            'version is string' => [[
+                'version' => '1.1',
+            ]],
+            'version is float' => [[
+                'version' => 1.1,
+            ]],
+        ];
     }
 }

--- a/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
+++ b/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * @version 2.1
  * @since   2015-05
  */
-class GuzzleExtensionTest extends TestCase
+class EightPointsGuzzleExtensionTest extends TestCase
 {
     public function testGuzzleExtension()
     {


### PR DESCRIPTION
- [ ] Bug fix
- [x] New feature
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests pass

Fixed tickets: [#97]
License: MIT

---

**Added options:**
 - allow_redirects - bool or array
 - form_params - array
 - multipart - array
 - sink - string

**Modified options:**
 - base_url - string (was boolean, string, integer, float and null)
 - auth - string or array (was array only)
 - query - string or array (was boolean, string, integer, float and null)
 - connect_timeout - float and int (was boolean, string, integer, float and null)
 - decode_content - string and bool (was bool) (Note: string in case of decoding, ex: gzip)
 - delay - float and int (was boolean, string, integer, float and null)
 - expect - bool or int (was boolean, string, integer, float and null)
 - ssl_key - string or array with two elements (was boolean, string, integer, float and null)
 - stream - bool (was bool or string)
 - synchronous - bool and string (was bool or string casted to string)
 - timeout - float or int (was boolean, string, integer, float and null)
 - verify - bool and string (was bool or string casted to string)
 - cookies - bool (was bool and string casted to bool)
 - version - string or float (was boolean, string, integer, float and null)

@florianpreusner I added more strict type for options and now it's fully compatible with guzzle docs. I also wrote tests for options. Any remarks or suggestions?

Guzzle docs: http://docs.guzzlephp.org/en/latest/request-options.html