### PR TITLE
Add reset method to HttpDataCollector. Required in symfony >= 3.4

### DIFF
--- a/src/DataCollector/HttpDataCollector.php
+++ b/src/DataCollector/HttpDataCollector.php
@@ -31,10 +31,8 @@ class HttpDataCollector extends DataCollector
     public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
-        $this->data = [
-            'logs' => [],
-            'callCount' => 0,
-        ];
+
+        $this->reset();
     }
 
     /**
@@ -65,6 +63,17 @@ class HttpDataCollector extends DataCollector
     public function getName() : string
     {
         return 'eight_points_guzzle';
+    }
+
+    /**
+     * Resets this data collector to its initial state.
+     */
+    public function reset()
+    {
+        $this->data = [
+            'logs' => [],
+            'callCount' => 0,
+        ];
     }
 
     /**

--- a/tests/DataCollector/HttpDataCollectorTest.php
+++ b/tests/DataCollector/HttpDataCollectorTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 class HttpDataCollectorTest extends TestCase
 {
     /**
-     * @var Logger
+     * @var Logger|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $logger;
 
@@ -182,6 +182,43 @@ class HttpDataCollectorTest extends TestCase
         $collector->collect($request, $response);
 
         $this->assertSame(2, $collector->getCallCount());
+    }
+
+    /**
+     * Test reset method
+     *
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::reset
+     */
+    public function testReset()
+    {
+        $this->logger->expects($this->once())
+            ->method('getMessages')
+            ->willReturn(['test message #1', 'test message #2']);
+
+        $collector = new HttpDataCollector($this->logger);
+
+        $response = $this->getMockBuilder(Response::class)
+            ->getMock();
+
+        $request = $this->getMockBuilder(Request::class)
+            ->getMock();
+
+        $request->expects($this->once())
+            ->method('getUri')
+            ->willReturn('someRandomUrlId');
+
+        $request->expects($this->once())
+            ->method('getPathInfo')
+            ->willReturn('id');
+
+        $collector->collect($request, $response);
+
+        $this->assertSame(2, $collector->getCallCount());
+
+        $collector->reset();
+
+        $this->assertSame(0, $collector->getCallCount());
+        $this->assertCount(0, $collector->getLogs());
     }
 
     /**


### PR DESCRIPTION
- [x] Bug fix
- [ ] New feature
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests pass

Fixed tickets: [#141]
License: MIT
