### PR TITLE
[FIX] Add names to middlewares

### DIFF
--- a/src/DependencyInjection/EightPointsGuzzleExtension.php
+++ b/src/DependencyInjection/EightPointsGuzzleExtension.php
@@ -123,14 +123,14 @@ class EightPointsGuzzleExtension extends Extension
 
         $handler = new Definition(HandlerStack::class);
         $handler->setFactory([HandlerStack::class, 'create']);
+        $handler->addMethodCall('push', [$logExpression, 'log']);
 
         foreach ($this->plugins as $plugin) {
             $plugin->loadForClient($config['plugin'][$plugin->getPluginName()], $container, $name, $handler);
         }
 
-        $handler->addMethodCall('push', [$logExpression]);
         // goes on the end of the stack.
-        $handler->addMethodCall('unshift', [$eventExpression]);
+        $handler->addMethodCall('unshift', [$eventExpression, 'events']);
 
         return $handler;
     }


### PR DESCRIPTION
- [x] Bug fix
- [ ] New feature
- [ ] BC breaks
- [ ] Deprecations
- [ ] Tests pass

Fixed tickets: [comma-separated list of tickets fixed by the PR, if any]
License: MIT

Allow the use of `HandlerStack::before($name,...)` and `HandlerStack::after($name,...)`
