### PR TITLE
Config and HttpDataCollector improvements

### DIFF
--- a/src/DataCollector/HttpDataCollector.php
+++ b/src/DataCollector/HttpDataCollector.php
@@ -5,6 +5,8 @@ namespace EightPoints\Bundle\GuzzleBundle\DataCollector;
 use EightPoints\Bundle\GuzzleBundle\Log\LogGroup;
 use EightPoints\Bundle\GuzzleBundle\Log\LoggerInterface;
 use EightPoints\Bundle\GuzzleBundle\Log\Logger;
+use EightPoints\Bundle\GuzzleBundle\Log\LogMessage;
+use Psr\Log\LogLevel;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -133,7 +135,9 @@ class HttpDataCollector extends DataCollector
      */
     public function getErrorCount() : int
     {
-        return 0; //@todo
+        return count(array_filter($this->getMessages(), function (LogMessage $message) {
+            return $message->getLevel() === LogLevel::ERROR;
+        }));
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -90,6 +90,12 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->arrayNode('options')
+                        ->validate()
+                            ->ifTrue(function ($options) {
+                                return count($options['form_params']) && count($options['multipart']);
+                            })
+                            ->thenInvalid('You cannot use form_params and multipart at the same time.')
+                        ->end()
                         ->children()
                             ->arrayNode('headers')
                                 ->normalizeKeys(false)

--- a/src/Log/Logger.php
+++ b/src/Log/Logger.php
@@ -12,7 +12,7 @@ class Logger implements LoggerInterface
 {
     use LoggerTrait;
 
-    /** @var array */
+    /** @var LogMessage[] */
     private $messages = [];
 
     /**
@@ -75,7 +75,7 @@ class Logger implements LoggerInterface
      * @version 2.1
      * @since   2014-11
      *
-     * @return  array
+     * @return  LogMessage[]
      */
     public function getMessages() : array
     {

--- a/tests/DataCollector/HttpDataCollectorTest.php
+++ b/tests/DataCollector/HttpDataCollectorTest.php
@@ -5,7 +5,9 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests\DataCollector;
 use EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector;
 use EightPoints\Bundle\GuzzleBundle\Log\Logger;
 use EightPoints\Bundle\GuzzleBundle\Log\LogGroup;
+use EightPoints\Bundle\GuzzleBundle\Log\LogMessage;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -231,7 +233,35 @@ class HttpDataCollectorTest extends TestCase
      */
     public function testErrorCount()
     {
-        $this->markTestSkipped('must be implemented.');
+        $errorMessage = new LogMessage('error log message');
+        $errorMessage->setLevel(LogLevel::ERROR);
+
+        $infoMessage = new LogMessage('info log message');
+        $infoMessage->setLevel(LogLevel::INFO);
+
+        $this->logger->expects($this->once())
+            ->method('getMessages')
+            ->willReturn([$errorMessage, $infoMessage]);
+
+        $collector = new HttpDataCollector($this->logger);
+
+        $response = $this->getMockBuilder(Response::class)
+            ->getMock();
+
+        $request = $this->getMockBuilder(Request::class)
+            ->getMock();
+
+        $request->expects($this->once())
+            ->method('getUri')
+            ->willReturn('someRandomUrlId');
+
+        $request->expects($this->once())
+            ->method('getPathInfo')
+            ->willReturn('id');
+
+        $collector->collect($request, $response);
+
+        $this->assertEquals(1, $collector->getErrorCount());
     }
 
     /**

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -234,28 +234,6 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($curlConfig[CURLOPT_SSLVERSION], CURL_HTTP_VERSION_1_1);
     }
 
-    public function testInvalidCurlOption()
-    {
-        $this->expectException(InvalidConfigurationException::class);
-
-        $config = [
-            'eight_points_guzzle' => [
-                'clients' => [
-                    'test_client' => [
-                        'options' => [
-                            'curl' => [
-                                'invalid_option' => true,
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ];
-
-        $processor = new Processor();
-        $processor->processConfiguration(new Configuration('eight_points_guzzle'), $config);
-    }
-
     /**
      * @dataProvider provideValidOptionValues
      *
@@ -386,6 +364,67 @@ class ConfigurationTest extends TestCase
             'version is float' => [[
                 'version' => 1.1,
             ]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidOptionValues
+     *
+     * @param array $options
+     * @param string $exceptionMessage
+     */
+    public function testInvalidOptions(array $options, string $exceptionMessage)
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage($exceptionMessage);
+
+        $config = [
+            'eight_points_guzzle' => [
+                'clients' => [
+                    'test_client' => [
+                        'options' => $options
+                    ]
+                ]
+            ]
+        ];
+
+        $processor = new Processor();
+        $processor->processConfiguration(new Configuration('eight_points_guzzle'), $config);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideInvalidOptionValues() : array
+    {
+        return [
+            'form_params and multipart at the same time' => [
+                'options' => [
+                    'form_params' => ['foo' => 'bar'],
+                    'multipart' => ['baz' => 'bar'],
+                ],
+                'exception message' => 'You cannot use form_params and multipart at the same time.',
+            ],
+            'invalid curl option' => [
+                'options' => [
+                    'curl' => [
+                        'invalid_option' => true,
+                    ],
+                ],
+                'exception message' => 'Invalid curl option',
+            ],
+            'cert as array with one value' => [
+                'options' => [
+                    'cert' => ['/path/to/cert.pem'],
+                ],
+                'exception message' => 'cert can be: string or array with two entries',
+            ],
+            'ssl_key as array with one value' => [
+                'options' => [
+                    'ssl_key' => ['/path/to/cert.pem'],
+                ],
+                'exception message' => 'ssl_key can be: string or array with two entries',
+            ],
         ];
     }
 }

--- a/tests/Log/LoggerTest.php
+++ b/tests/Log/LoggerTest.php
@@ -9,6 +9,7 @@ use EightPoints\Bundle\GuzzleBundle\Log\LogRequest;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
 
 /**
  * Class LoggerTest
@@ -44,7 +45,7 @@ class LoggerTest extends TestCase
         $logger = new Logger();
         $this->assertFalse($logger->hasMessages());
 
-        $logger->log('test', 'test message');
+        $logger->log(LogLevel::ERROR, 'test message');
         $this->assertTrue($logger->hasMessages());
     }
 
@@ -61,10 +62,10 @@ class LoggerTest extends TestCase
         $logger = new Logger();
         $this->assertCount(0, $logger->getMessages());
 
-        $logger->log('test', 'test message');
+        $logger->log(LogLevel::ERROR, 'test message');
         $this->assertCount(1, $logger->getMessages());
 
-        $logger->log('test', 'second test message');
+        $logger->log(LogLevel::ERROR, 'second test message');
         $this->assertCount(2, $logger->getMessages());
 
         $messages = $logger->getMessages();
@@ -72,7 +73,7 @@ class LoggerTest extends TestCase
         /** @var LogMessage $message */
         foreach ($messages as $message) {
             $this->assertInstanceOf(LogMessage::class, $message);
-            $this->assertSame('test', $message->getLevel());
+            $this->assertSame(LogLevel::ERROR, $message->getLevel());
             $this->assertContains('test message', $message->getMessage());
             $this->assertNull($message->getRequest());
             $this->assertNull($message->getResponse());
@@ -89,10 +90,10 @@ class LoggerTest extends TestCase
         $requestMock->method('getHeaders')->willReturn([]);
         $requestMock->method('getUri')->willReturn($uriMock);
 
-        $logger->log('info', 'info message', ['request' => $requestMock]);
+        $logger->log(LogLevel::INFO, 'info message', ['request' => $requestMock]);
 
         $message = $logger->getMessages()[2];
-        $this->assertSame('info', $message->getLevel());
+        $this->assertSame(LogLevel::INFO, $message->getLevel());
         $this->assertSame('info message', $message->getMessage());
 
         $this->assertInstanceOf(LogRequest::class, $message->getRequest());
@@ -109,8 +110,8 @@ class LoggerTest extends TestCase
     public function testClear()
     {
         $logger = new Logger();
-        $logger->log('test', 'test message');
-        $logger->log('test', 'test message');
+        $logger->log(LogLevel::ERROR, 'test message');
+        $logger->log(LogLevel::ERROR, 'test message');
 
         $this->assertCount(2, $logger->getMessages());
         $this->assertTrue($logger->hasMessages());


### PR DESCRIPTION
- [ ] Bug fix
- [x] New feature
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests pass

Fixed tickets: []
License: MIT

What I did:
- Validate that form_params and multipart can't be used at the same time
- HttpDataCollector::getErrorCount method (there was TODO)
- Improve annotation for logger
- Tests for invalid options and HttpDataCollector::getErrorCount