### PR TITLE
Deactivate logger/data collector/formatter/log middleware if logging is false

### DIFF
--- a/src/DependencyInjection/EightPointsGuzzleExtension.php
+++ b/src/DependencyInjection/EightPointsGuzzleExtension.php
@@ -70,6 +70,7 @@ class EightPointsGuzzleExtension extends Extension
         if ($logging) {
             $this->defineLogger($container);
             $this->defineDataCollector($container);
+            $this->defineFormatter($container);
         }
 
         foreach ($config['clients'] as $name => $options) {
@@ -170,6 +171,19 @@ class EightPointsGuzzleExtension extends Extension
             'template' => '@EightPointsGuzzle/debug.html.twig',
         ]);
         $container->setDefinition('eight_points_guzzle.data_collector', $dataCollectorDefinition);
+    }
+
+    /**
+     * Define Formatter
+     *
+     * @param  ContainerBuilder $container
+     *
+     * @throws \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
+     */
+    protected function defineFormatter(ContainerBuilder $container)
+    {
+        $formatterDefinition = new Definition('%eight_points_guzzle.formatter.class%');
+        $container->setDefinition('eight_points_guzzle.formatter', $formatterDefinition);
     }
 
     /**

--- a/src/DependencyInjection/EightPointsGuzzleExtension.php
+++ b/src/DependencyInjection/EightPointsGuzzleExtension.php
@@ -165,6 +165,7 @@ class EightPointsGuzzleExtension extends Extension
     protected function defineDataCollector(ContainerBuilder $container)
     {
         $dataCollectorDefinition = new Definition('%eight_points_guzzle.data_collector.class%');
+        $dataCollectorDefinition->addArgument(new Reference('eight_points_guzzle.logger'));
         $dataCollectorDefinition->setPublic(false);
         $dataCollectorDefinition->addTag('data_collector', [
             'id' => 'eight_points_guzzle',

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -17,9 +17,4 @@
 
         <parameter key="eight_points_guzzle.plugin.header.headers" type="collection" />
     </parameters>
-
-    <services>
-        <!-- Formatter -->
-        <service id="eight_points_guzzle.formatter" class="%eight_points_guzzle.formatter.class%" />
-    </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -21,11 +21,5 @@
     <services>
         <!-- Formatter -->
         <service id="eight_points_guzzle.formatter" class="%eight_points_guzzle.formatter.class%" />
-
-        <!-- Data Collector -->
-        <service id="eight_points_guzzle.data_collector" class="%eight_points_guzzle.data_collector.class%" public="false">
-            <tag name="data_collector" template="@EightPointsGuzzle/debug.html.twig" id="eight_points_guzzle" />
-            <argument type="service" id="eight_points_guzzle.logger" />
-        </service>
     </services>
 </container>

--- a/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
+++ b/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
@@ -71,6 +71,7 @@ class EightPointsGuzzleExtensionTest extends TestCase
         // test logging services (logger, data collector and log middleware for each client)
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.logger'));
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.data_collector'));
+        $this->assertTrue($container->hasDefinition('eight_points_guzzle.formatter'));
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.log.test_api'));
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.log.test_api_with_custom_class'));
 
@@ -90,6 +91,7 @@ class EightPointsGuzzleExtensionTest extends TestCase
 
         $this->assertFalse($container->hasDefinition('eight_points_guzzle.logger'));
         $this->assertFalse($container->hasDefinition('eight_points_guzzle.data_collector'));
+        $this->assertFalse($container->hasDefinition('eight_points_guzzle.formatter'));
         $this->assertFalse($container->hasDefinition('eight_points_guzzle.middleware.log.test_api'));
         $this->assertFalse($container->hasDefinition('eight_points_guzzle.middleware.log.test_api_with_custom_class'));
 

--- a/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
+++ b/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
@@ -5,10 +5,12 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests\DependencyInjection;
 use EightPoints\Bundle\GuzzleBundle\DependencyInjection\Configuration;
 use EightPoints\Bundle\GuzzleBundle\DependencyInjection\EightPointsGuzzleExtension;
 use EightPoints\Bundle\GuzzleBundle\Tests\DependencyInjection\Fixtures\FakeClient;
-use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Uri;
 
 /**
  * @version 2.1
@@ -25,11 +27,10 @@ class EightPointsGuzzleExtensionTest extends TestCase
         // test Client
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.client.test_api'));
         $testApi = $container->get('eight_points_guzzle.client.test_api');
-        $this->assertInstanceOf('GuzzleHttp\Client', $testApi);
+        $this->assertInstanceOf(Client::class, $testApi);
         $this->assertEquals(new Uri('//api.domain.tld/path'), $testApi->getConfig('base_uri'));
 
         // test Services
-        $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.log.test_api'));
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.event_dispatch.test_api'));
 
         // test Client with custom class
@@ -48,6 +49,53 @@ class EightPointsGuzzleExtensionTest extends TestCase
 
         $client = $container->get('eight_points_guzzle.client.test_api', FakeClient::class);
         $this->assertInstanceOf(FakeClient::class, $client);
+    }
+
+    public function testLoadWithLogging()
+    {
+        $config = $this->getConfigs();
+        $config[0]['logging'] = true;
+
+        $container = $this->createContainer();
+        $extension = new EightPointsGuzzleExtension();
+        $extension->load($config, $container);
+
+        // test Client
+        $this->assertTrue($container->hasDefinition('eight_points_guzzle.client.test_api'));
+        $this->assertTrue($container->hasDefinition('eight_points_guzzle.client.test_api_with_custom_class'));
+
+        // test Services
+        $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.log.test_api'));
+        $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.event_dispatch.test_api'));
+
+        // test logging services (logger, data collector and log middleware for each client)
+        $this->assertTrue($container->hasDefinition('eight_points_guzzle.logger'));
+        $this->assertTrue($container->hasDefinition('eight_points_guzzle.data_collector'));
+        $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.log.test_api'));
+        $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.log.test_api_with_custom_class'));
+
+        // test log middleware in handler of the client
+        $this->assertCount(1, $this->getClientLogMiddleware($container, 'eight_points_guzzle.client.test_api'));
+        $this->assertCount(1, $this->getClientLogMiddleware($container, 'eight_points_guzzle.client.test_api_with_custom_class'));
+    }
+
+    public function testLoadWithoutLogging()
+    {
+        $config = $this->getConfigs();
+        $config[0]['logging'] = false;
+
+        $container = $this->createContainer();
+        $extension = new EightPointsGuzzleExtension();
+        $extension->load($config, $container);
+
+        $this->assertFalse($container->hasDefinition('eight_points_guzzle.logger'));
+        $this->assertFalse($container->hasDefinition('eight_points_guzzle.data_collector'));
+        $this->assertFalse($container->hasDefinition('eight_points_guzzle.middleware.log.test_api'));
+        $this->assertFalse($container->hasDefinition('eight_points_guzzle.middleware.log.test_api_with_custom_class'));
+
+        // test log middleware in handler of the client
+        $this->assertCount(0, $this->getClientLogMiddleware($container, 'eight_points_guzzle.client.test_api'));
+        $this->assertCount(0, $this->getClientLogMiddleware($container, 'eight_points_guzzle.client.test_api_with_custom_class'));
     }
 
     public function testGetConfiguration()
@@ -88,5 +136,26 @@ class EightPointsGuzzleExtensionTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param string $clientName
+     *
+     * @return array
+     */
+    protected function getClientLogMiddleware(ContainerBuilder $container, string $clientName) : array
+    {
+        $this->assertCount(1, $container->getDefinition($clientName)->getArguments());
+        $clientOptions = $container->getDefinition($clientName)->getArgument(0);
+        $this->assertArrayHasKey('handler', $clientOptions);
+
+        /** @var Definition $handler */
+        $handler = $clientOptions['handler'];
+        $this->assertInstanceOf(Definition::class, $handler);
+
+        return array_filter($handler->getMethodCalls(), function(array $a) {
+            return isset($a[1][1]) && $a[1][1] === 'log';
+        });
     }
 }


### PR DESCRIPTION
- [ ] Bug fix
- [x] New feature
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests pass

Fixed tickets: [#72]
License: MIT

@florianpreusner so, if logging in configuration is false, then logger, data collector, formatter and log middleware are not defined at all and visa versa. I also wrote tests for these cases :slightly_smiling_face: 