### PR TITLE
PostTransactionEvent > Remove strict return type to allow null

### DIFF
--- a/src/Events/PostTransactionEvent.php
+++ b/src/Events/PostTransactionEvent.php
@@ -28,9 +28,9 @@ class PostTransactionEvent extends Event
      *
      * This returns the transaction we are working with.
      *
-     * @return ResponseInterface
+     * @return ResponseInterface|null
      */
-    public function getTransaction() : ResponseInterface
+    public function getTransaction()
     {
         return $this->response;
     }


### PR DESCRIPTION
Found this exception:
```
Type error: Return value of EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent::getTransaction() must be an instance of Psr\Http\Message\ResponseInterface, null returned
```

Checked the code and the issue is the strict return type. Cannot use ` : ?ResponseInterface` because this project also supports PHP 7.0
