### PR TITLE
Add reset method to HttpDataCollector. Required in symfony >= 3.4

### DIFF
--- a/DataCollector/HttpDataCollector.php
+++ b/DataCollector/HttpDataCollector.php
@@ -33,10 +33,8 @@ class HttpDataCollector extends DataCollector
     public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
-        $this->data = array(
-            'logs' => array(),
-            'callCount' => 0,
-        );
+
+        $this->reset();
     }
 
     /**
@@ -67,6 +65,17 @@ class HttpDataCollector extends DataCollector
     public function getName()
     {
         return 'guzzle';
+    }
+
+    /**
+     * Resets this data collector to its initial state.
+     */
+    public function reset()
+    {
+        $this->data = [
+            'logs' => [],
+            'callCount' => 0,
+        ];
     }
 
     /**

--- a/Tests/DataCollector/HttpDataCollectorTest.php
+++ b/Tests/DataCollector/HttpDataCollectorTest.php
@@ -11,7 +11,7 @@ use EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector;
 class HttpDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \EightPoints\Bundle\GuzzleBundle\Log\Logger
+     * @var \EightPoints\Bundle\GuzzleBundle\Log\Logger|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $logger;
 
@@ -165,6 +165,43 @@ class HttpDataCollectorTest extends \PHPUnit_Framework_TestCase
         $collector->collect($request, $response);
 
         $this->assertSame(2, $collector->getCallCount());
+    }
+
+    /**
+     * Test reset method
+     *
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::reset
+     */
+    public function testReset()
+    {
+        $this->logger->expects($this->once())
+            ->method('getMessages')
+            ->willReturn(['test message #1', 'test message #2']);
+
+        $collector = new HttpDataCollector($this->logger);
+
+        $response = $this->getMockBuilder(Response::class)
+            ->getMock();
+
+        $request = $this->getMockBuilder(Request::class)
+            ->getMock();
+
+        $request->expects($this->once())
+            ->method('getUri')
+            ->willReturn('someRandomUrlId');
+
+        $request->expects($this->once())
+            ->method('getPathInfo')
+            ->willReturn('id');
+
+        $collector->collect($request, $response);
+
+        $this->assertSame(2, $collector->getCallCount());
+
+        $collector->reset();
+
+        $this->assertSame(0, $collector->getCallCount());
+        $this->assertCount(0, $collector->getLogs());
     }
 
     /**

--- a/Tests/DataCollector/HttpDataCollectorTest.php
+++ b/Tests/DataCollector/HttpDataCollectorTest.php
@@ -180,10 +180,10 @@ class HttpDataCollectorTest extends \PHPUnit_Framework_TestCase
 
         $collector = new HttpDataCollector($this->logger);
 
-        $response = $this->getMockBuilder(Response::class)
+        $response = $this->getMockBuilder('Symfony\Component\HttpFoundation\Response')
             ->getMock();
 
-        $request = $this->getMockBuilder(Request::class)
+        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
             ->getMock();
 
         $request->expects($this->once())


### PR DESCRIPTION
See PR https://github.com/8p/EightPointsGuzzleBundle/pull/142 for fix in GuzzleBundle v7

| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | https://github.com/8p/EightPointsGuzzleBundle/issues/141
| License          | MIT
