### PR TITLE
Review dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ _Note: for symfony 3.3 and 3.4 you should install symfony/flex by yourself. From
 ----
 
 ## Usage
-Load bundle in AppKernel.php:
+##### Load bundle in AppKernel.php:
 ``` php
 new EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundle()
 ```
 
-Configuration in config.yml:
+##### Configuration in config.yml:
 ``` yaml
 eight_points_guzzle:
     # (de)activate logging/profiler; default: %kernel.debug%
@@ -109,6 +109,15 @@ eight_points_guzzle:
 ```
 Allowed options: headers, allow_redirects, auth, query, curl, cert, connect_timeout, debug, decode_content, delay, form_params, multipart, sink, http_errors, expect, ssl_key, stream, synchronous, timeout, verify, cookies, proxy, version. All these settings are optional.  
 Description for all options and examples of parameters can be found [here][4].
+
+##### Install assets _(if it's not performed automatically)_:
+``` bash
+# for symfony >= 3.0
+bin/console assets:install
+
+# for symfony < 3.0
+app/console assets:install
+```
 
 Using services in controller (eight_points_guzzle.client.**api_crm** represents the client name of the yaml config and is an instance of GuzzleHttp\Client):
 ``` php

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,15 @@
     }
   ],
   "require": {
-    "php":                                ">=7.0",
-    "guzzlehttp/guzzle":                  "~6.0",
-    "symfony/dependency-injection":       "~2.7|~3.0|~4.0",
-    "symfony/expression-language":        "~2.7|~3.0|~4.0",
-    "symfony/event-dispatcher":           "~2.7|~3.0|~4.0",
-    "symfony/http-kernel":                "~2.7|~3.0|~4.0",
-    "psr/log":                            "~1.0"
+    "php":                          ">=7.0",
+    "guzzlehttp/guzzle":            "~6.0",
+    "symfony/framework-bundle":     "~2.7|~3.0|~4.0",
+    "symfony/expression-language":  "~2.7|~3.0|~4.0",
+    "psr/log":                      "~1.0"
   },
   "require-dev": {
     "phpunit/phpunit":    "~6.1",
     "twig/twig":          "~1.5|~2.0",
-    "symfony/config":     "~2.7|~3.0|~4.0",
     "symfony/var-dumper": "~2.7|~3.0|~4.0"
   },
   "autoload": {


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | no
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | #172 
| License          | MIT

What I did:
 - added `assets:install` command in readme, because sometimes this command is not performed automatically and we should provide information about that.
 - added `symfony/framework-bundle` in dependencies, because there are some features that bundle uses. For example `assets` function for this is defined there and also command `assets:install`. And as I see, many bundles are dependent on this package.
- removed `symfony/dependency-injection`, `symfony/event-dispatcher`, `symfony/http-kernel` and `symfony/config` because these packages are provided by `symfony/framework-bundle`.

Merry Christmas :christmas_tree: :snowflake: :slightly_smiling_face:  