### PR TITLE
Allow to use environment variables for timeouts

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -156,7 +156,19 @@ class Configuration implements ConfigurationInterface
                                     ->thenInvalid('cert can be: string or array with two entries (path and password)')
                                 ->end()
                             ->end()
-                            ->floatNode('connect_timeout')->end()
+                            ->scalarNode('connect_timeout')
+                                ->beforeNormalization()
+                                    ->always(function ($v) {
+                                        return is_numeric($v) ? (float) $v : $v;
+                                    })
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_float($v) && !(is_string($v) && strpos($v, 'env_') === 0);
+                                    })
+                                    ->thenInvalid('connect_timeout can be: float')
+                                ->end()
+                            ->end()
                             ->booleanNode('debug')->end()
                             ->variableNode('decode_content')
                                 ->validate()
@@ -202,7 +214,32 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->booleanNode('stream')->end()
                             ->booleanNode('synchronous')->end()
-                            ->floatNode('timeout')->end()
+                            ->scalarNode('read_timeout')
+                                ->beforeNormalization()
+                                    ->always(function ($v) {
+                                        return is_numeric($v) ? (float) $v : $v;
+                                    })
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_float($v) && !(is_string($v) && strpos($v, 'env_') === 0);
+                                    })
+                                    ->thenInvalid('read_timeout can be: float')
+                                ->end()
+                            ->end()
+                            ->scalarNode('timeout')
+                                ->beforeNormalization()
+                                    ->always(function ($v) {
+                                        return is_numeric($v) ? (float) $v : $v;
+                                    })
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_float($v) && !(is_string($v) && strpos($v, 'env_') === 0);
+                                    })
+                                    ->thenInvalid('timeout can be: float')
+                                ->end()
+                            ->end()
                             ->variableNode('verify')
                                 ->validate()
                                     ->ifTrue(function ($v) {

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -39,6 +39,7 @@ class ConfigurationTest extends TestCase
                             'stream' => true,
                             'synchronous' => true,
                             'timeout' => 30,
+                            'read_timeout' => 30,
                             'verify' => true,
                             'proxy' => [
                                 'http' => 'http://proxy.org',
@@ -93,6 +94,7 @@ class ConfigurationTest extends TestCase
                             'stream' => true,
                             'synchronous' => true,
                             'timeout' => 30,
+                            'read_timeout' => 30,
                             'verify' => true,
                             'version' => '1.1',
                         ],
@@ -292,6 +294,15 @@ class ConfigurationTest extends TestCase
             'connect_timeout is float' => [[
                 'connect_timeout' => 3.14,
             ]],
+            'connect_timeout is string' => [[
+                'connect_timeout' => '3.14',
+            ]],
+            'connect_timeout is pure environment variable' => [[
+                'connect_timeout' => 'env_CONNECT_TIMEOUT_62364f6ed52bf3207e119ceff9760661',
+            ]],
+            'connect_timeout is type-casted environment variable' => [[
+                'connect_timeout' => 'env_float_CONNECT_TIMEOUT_62364f6ed52bf3207e119ceff9760661',
+            ]],
             'decode_content is boolean' => [[
                 'decode_content' => true,
             ]],
@@ -334,6 +345,27 @@ class ConfigurationTest extends TestCase
             ]],
             'timeout is float' => [[
                 'timeout' => 3.14,
+            ]],
+            'timeout is string' => [[
+                'timeout' => '3.14',
+            ]],
+            'timeout is pure environment variable' => [[
+                'timeout' => 'env_TIMEOUT_62364f6ed52bf3207e119ceff9760661',
+            ]],
+            'timeout is type-casted environment variable' => [[
+                'timeout' => 'env_float_TIMEOUT_62364f6ed52bf3207e119ceff9760661',
+            ]],
+            'read_timeout is float' => [[
+                'read_timeout' => 3.14,
+            ]],
+            'read_timeout is string' => [[
+                'read_timeout' => '3.14',
+            ]],
+            'read_timeout is pure environment variable' => [[
+                'read_timeout' => 'env_READ_TIMEOUT_62364f6ed52bf3207e119ceff9760661',
+            ]],
+            'read_timeout is type-casted environment variable' => [[
+                'connect_timeout' => 'env_float_READ_TIMEOUT_62364f6ed52bf3207e119ceff9760661',
             ]],
             'verify is bool' => [[
                 'verify' => true,


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | no
| New feature      | yes
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | 
| License          | MIT

This PR adds `read_timeout` option for guzzle client and allows using environment variables for `connect_timeout`, `read_timeout` and `timeout` settings.