### PR TITLE
Fix twig extension incompatibility

### DIFF
--- a/src/Twig/Extension/DebugExtension.php
+++ b/src/Twig/Extension/DebugExtension.php
@@ -41,4 +41,12 @@ class DebugExtension extends \Twig_Extension
 
         return stream_get_contents($dump);
     }
+
+    /**
+     * @return string
+     */
+    public function getName() : string
+    {
+        return get_class($this);
+    }
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | []
| License          | MIT

In twig/twig 1.x `Twig_ExtensionInterface` declares `getName` which the current `DebugExtension` is missing.