### PR TITLE
Add auth configuration to v6 branch in configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -96,8 +96,12 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('scalar')
                                 ->end()
                             ->end()
-                            ->arrayNode('auth')
-                                ->prototype('scalar')
+                            ->variableNode('auth')
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_array($v) && !is_string($v);
+                                    })
+                                    ->thenInvalid('auth can be: string or array')
                                 ->end()
                             ->end()
                             ->arrayNode('query')


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | no
| New feature      | yes
| BC breaks        | no
| Deprecations     | no
| Tests pass       | unknown
| Fixed tickets    | 
| License          | MIT

Pulled changes from the newest version to v6 allowing auth headers to be a string or an array.