### PR TITLE
Doc: how to redefine client class

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ services:
 
 ----
 
+## Learn more
+- [How to redefine class used for clients](src/Resources/doc/redefine-client-class.md)
+
 ## License
 This bundle is released under the [MIT license](src/Resources/meta/LICENSE)
 

--- a/src/Resources/doc/redefine-client-class.md
+++ b/src/Resources/doc/redefine-client-class.md
@@ -1,7 +1,7 @@
 # How to redefine class used for clients
 
 GuzzleBundle is using `GuzzleHttp\Client` class to create clients. In some cases you may need to extend/rewrite it.
-First of all you need to crete your own class, but don't forget to extend `GuzzleHttp\Client`:
+First of all you need to create your own class, but don't forget to extend `GuzzleHttp\Client`:
 
 ```php
 
@@ -27,7 +27,7 @@ parameters:
     eight_points_guzzle.http_client.class: Namespace\Of\Your\Client\AwesomeClient
 ```
 
-Note that this method will redefine class for all clients.
+Note that this method will redefine class for **all** clients.
 
 #### For specific client
 

--- a/src/Resources/doc/redefine-client-class.md
+++ b/src/Resources/doc/redefine-client-class.md
@@ -1,0 +1,41 @@
+# How to redefine class used for clients
+
+GuzzleBundle is using `GuzzleHttp\Client` class to create clients. In some cases you may need to extend/rewrite it.
+First of all you need to crete your own class, but don't forget to extend `GuzzleHttp\Client`:
+
+```php
+
+namespace Namespace\Of\Your\Client;
+
+use GuzzleHttp\Client;
+
+class AwesomeClient extends Client
+{
+
+}
+```
+
+And now we have two possibilities to change the default class:
+
+#### Global
+
+Redefine `eight_points_guzzle.http_client.class` parameter.
+For example in `config/services.yaml` for Symfony 4 and in `app/config/parameters.yml` in Symfony 2 and 3:
+
+```yaml
+parameters:
+    eight_points_guzzle.http_client.class: Namespace\Of\Your\Client\AwesomeClient
+```
+
+Note that this method will redefine class for all clients.
+
+#### For specific client
+
+```yaml
+eight_points_guzzle:
+    clients:
+        api_payment:
+            class: 'Namespace\Of\Your\Client\AwesomeClient'
+```
+
+This method will redefine client class only for specific GuzzleBundle client.


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | no
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | #181
| License          | MIT

@florianpreusner I created separate page for this article not not to inflate the main readme. I think next doc articles will do in the same way. To separate them how symfony does with official documentation. What do you think? 

Preview: https://github.com/gregurco/EightPointsGuzzleBundle/blob/doc_redefine_client/src/Resources/doc/redefine-client-class.md :slightly_smiling_face: 