### PR TITLE
 Fix rendering of templates in v6 and SF >= 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ php:
     - nightly
 
 env:
-    - SYMFONY_VERSION=2.7.*
-    - SYMFONY_VERSION=2.8.*
-    - SYMFONY_VERSION=3.0.*
-    - SYMFONY_VERSION=3.1.*
-    - SYMFONY_VERSION=dev-master
+    - SYMFONY_VERSION=3.2.*
+    - SYMFONY_VERSION=3.3.*
+    - SYMFONY_VERSION=3.4.*
 
 before_script:
     - composer self-update
@@ -28,15 +26,12 @@ matrix:
         - env: SYMFONY_VERSION=dev-master
         - php: nightly
     include:
-        - env: SYMFONY_VERSION=2.7.*
+        - env: SYMFONY_VERSION=3.2.*
           php: hhvm
           dist: trusty
-        - env: SYMFONY_VERSION=2.8.*
+        - env: SYMFONY_VERSION=3.3.*
           php: hhvm
           dist: trusty
-        - env: SYMFONY_VERSION=3.0.*
-          php: hhvm
-          dist: trusty
-        - env: SYMFONY_VERSION=3.1.*
+        - env: SYMFONY_VERSION=3.4.*
           php: hhvm
           dist: trusty

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ GuzzleBundle follows semantic versioning. Read more on [semver.org][2].
 
 ----
 
+## :exclamation: Important :exclamation:
+
+Use v7 of Guzzle Bundle! Just critical issues are fixed in v6.
+
+Compatibility table:
+
+| PHP      | Symfony    | Guzzle Bundle |
+|----------|------------|---------------|
+| 5.x, 7.x | ~          | v7            |
+| 5.x      | 3.2 - 3.4  | v6.2.1        |
+| 5.x      | 2.8 - 3.2  | v6.2.0        |
+
+----
+
 ## Requirements
  - PHP 5.6 or above
  - Symfony 2.7 or above

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -28,7 +28,7 @@
 
 		<!-- Data Collector -->
         <service id="guzzle_bundle.data_collector" class="%guzzle_bundle.data_collector.class%" public="false">
-            <tag name="data_collector" template="GuzzleBundle::debug" id="guzzle" />
+            <tag name="data_collector" template="@Guzzle/debug.html.twig" id="guzzle" />
             <argument type="service" id="guzzle_bundle.logger" />
         </service>
     </services>

--- a/Resources/views/debug.html.twig
+++ b/Resources/views/debug.html.twig
@@ -1,4 +1,4 @@
-{% extends "WebProfilerBundle:Profiler:layout.html.twig" %}
+{% extends "@WebProfiler/Profiler/layout.html.twig" %}
 
 
 {% block toolbar %}
@@ -44,7 +44,7 @@
             </div>
         {% endset %}
 
-        {% include "WebProfilerBundle:Profiler:toolbar_item.html.twig" with { "link": profiler_url, status: status_color } %}
+        {% include "@WebProfiler/Profiler/toolbar_item.html.twig" with { "link": profiler_url, status: status_color } %}
     {% endif %}
 {% endblock %}
 
@@ -75,5 +75,5 @@
 
     <h2>Logs</h2>
 
-    {% include 'GuzzleBundle::profiler.html.twig' with { 'collector': collector } %}
+    {% include '@Guzzle/profiler.html.twig' with { 'collector': collector } %}
 {% endblock %}

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
     "php":                                ">=5.6",
     "guzzlehttp/guzzle":                  "~6.0",
     "eightpoints/guzzle-wsse-middleware": "~4.0",
-    "symfony/dependency-injection":       "~2.3|~3.0",
-    "symfony/expression-language":        "~2.3|~3.0",
-    "symfony/event-dispatcher":           "~2.3|~3.0",
-    "symfony/http-kernel":                "~2.3|~3.0",
+    "symfony/dependency-injection":       "~3.2",
+    "symfony/expression-language":        "~3.2",
+    "symfony/event-dispatcher":           "~3.2",
+    "symfony/http-kernel":                "~3.2",
     "psr/log":                            "~1.0"
   },
   "require-dev": {


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | #199 
| License          | MIT

The staff related to calling of templates really was changed in SF3.2. I did changes and I guess we have next cases:
- PHP 5, SF 3.1 -> Guzzle Bundle v6.2.0
- PHP 5, SF 3.2 -> Guzzle Bundle v6.2.1 (new release with this fix)
- PHP 7, SF 3.2 -> Guzzle Bundle v7