### PR TITLE
[DOC] Disable throwing exceptions on HTTP errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ services:
 
 ## Learn more
 - [How to redefine class used for clients](src/Resources/doc/redefine-client-class.md)
+- [Disable throwing exceptions on HTTP errors (4xx and 5xx responses)](src/Resources/doc/disable-exception-on-http-error.md)
 
 ## License
 This bundle is released under the [MIT license](src/Resources/meta/LICENSE)

--- a/src/Resources/doc/disable-exception-on-http-error.md
+++ b/src/Resources/doc/disable-exception-on-http-error.md
@@ -1,0 +1,29 @@
+# Disable throwing exceptions on HTTP errors
+
+For example you are having configured next client:
+
+```yaml
+eight_points_guzzle:
+    clients:
+        api_payment:
+            base_url: "http://api.domain.tld"
+```
+
+and you are doing request, but exception is thrown in case when API returns, for example, response with code 400.
+It can be `RequestException`, `ClientException` or `ServerException`, but for some reasons you don't want to catch them.
+You just want to receive response and to work with it.  
+
+It's possible! Just setup `http_errors` to false:
+
+```yaml
+eight_points_guzzle:
+    clients:
+        api_payment:
+            base_url: "http://api.domain.tld"
+            options:
+                http_errors: false
+```
+
+Read more about this option in the [official Guzzle documentation][1].
+
+[1]: http://docs.guzzlephp.org/en/latest/request-options.html#http-errors


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | no
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | #204 
| License          | MIT

See how it looks like: https://github.com/gregurco/EightPointsGuzzleBundle/blob/disable_exception_on_http_error_doc/src/Resources/doc/disable-exception-on-http-error.md