### PR TITLE
Add symfony/stopwatch to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
   "require-dev": {
     "phpunit/phpunit":    "~6.1",
     "twig/twig":          "~1.5|~2.0",
-    "symfony/var-dumper": "~2.7|~3.0|~4.0"
+    "symfony/var-dumper": "~2.7|~3.0|~4.0",
+    "symfony/stopwatch":  "~2.7|~3.0|~4.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/Middleware/ProfileMiddlewareTest.php
+++ b/tests/Middleware/ProfileMiddlewareTest.php
@@ -2,17 +2,13 @@
 
 namespace EightPoints\Bundle\GuzzleBundle\Tests\Middleware;
 
-use EightPoints\Bundle\GuzzleBundle\Log\Logger;
-use EightPoints\Bundle\GuzzleBundle\Middleware\LogMiddleware;
 use EightPoints\Bundle\GuzzleBundle\Middleware\ProfileMiddleware;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Promise\PromiseInterface;
 use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Request;
-use Psr\Log\LogLevel;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 class ProfileMiddlewareTest extends TestCase


### PR DESCRIPTION
Remove useless imports

| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | #229
| License          | MIT

Composer doesn't download dev dependencies of our dependencies. So, `symfony/stopwatch` should be added directly to dev dependencies.