### PR TITLE
Non public profiler creates error in SF 2.8

### DIFF
--- a/src/DependencyInjection/EightPointsGuzzleExtension.php
+++ b/src/DependencyInjection/EightPointsGuzzleExtension.php
@@ -289,7 +289,7 @@ class EightPointsGuzzleExtension extends Extension
         $profileMiddlewareDefinitionName = sprintf('eight_points_guzzle.middleware.profile.%s', $clientName);
         $profileMiddlewareDefinition = new Definition('%eight_points_guzzle.middleware.profile.class%');
         $profileMiddlewareDefinition->addArgument(new Reference('debug.stopwatch'));
-        $profileMiddlewareDefinition->setPublic(false);
+        $profileMiddlewareDefinition->setPublic(true);
         $container->setDefinition($profileMiddlewareDefinitionName, $profileMiddlewareDefinition);
 
         $profileExpression = new Expression(sprintf("service('%s').profile()", $profileMiddlewareDefinitionName));


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | #235
| License          | MIT
