### PR TITLE
Review dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,13 @@
     "guzzlehttp/guzzle":            "~6.0",
     "symfony/framework-bundle":     "~2.7|~3.0|~4.0",
     "symfony/expression-language":  "~2.7|~3.0|~4.0",
+    "symfony/stopwatch":            "~2.7|~3.0|~4.0",
     "psr/log":                      "~1.0"
   },
   "require-dev": {
     "phpunit/phpunit":    "~6.1",
-    "twig/twig":          "~1.5|~2.0",
-    "symfony/var-dumper": "~2.7|~3.0|~4.0",
-    "symfony/stopwatch":  "~2.7|~3.0|~4.0"
+    "symfony/twig-bundle":"~2.7|~3.0|~4.0",
+    "symfony/var-dumper": "~2.7|~3.0|~4.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | no
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | -
| License          | MIT

I installed new clean symfony project using `symfony/skeleton` reposiroty and after that installed bundle.
What I propose to change:
- move `symfony/stopwatch` to required section. Because section `require-dev` is totally ignored when bundle is installed in project and we have to force this package to be installed. In `symfony/website-skeleton` it's installed by default.
- replace twig/twig with symfony/twig-bundle. We're registering `DebugExtension` as twig extension using tag `twig.extension` and this tag is handled by `symfony/twig-bundle`. This change will provide us in dev more real packages as it is in real symfony project and will give us possibility to write more accurate tests :slightly_smiling_face: 