### PR TITLE
[Tests] General improvement (symfony/phpunit-bridge, travis and new tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,20 @@ env:
     # - SYMFONY_VERSION=4.2.* # (11/2018, until 01/2020)
     # - SYMFONY_VERSION=4.3.* # (05/2019, until 07/2020)
     # - SYMFONY_VERSION=4.4.* # LTS (11/2019, until 11/2023)
-    - SYMFONY_VERSION=dev-master
+    - DEPENDENCIES=dev
 
 before_install:
     - composer self-update
-    - if [ "$DEPENDENCIES" == "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+    - if [ "$DEPENDENCIES" == "dev" ]; then composer config minimum-stability $DEPENDENCIES; fi;
     - if [ "$SYMFONY_VERSION" != "" ]; then composer --no-update require symfony/symfony:${SYMFONY_VERSION}; fi;
 
-install: composer update
+install:
+    - composer update
+    - vendor/bin/simple-phpunit install
 
-script: ./vendor/bin/phpunit --coverage-text
+script:
+    - composer validate --strict --no-check-lock
+    - vendor/bin/simple-phpunit --coverage-text --verbose
 
 notifications:
     email:
@@ -39,7 +43,7 @@ matrix:
         - php: 7
           env: SYMFONY_VERSION=4.1.* # requires PHP ^7.1.3
         - php: 7
-          env: SYMFONY_VERSION=dev-master # requires PHP ^7.1.3
+          env: DEPENDENCIES=dev # requires PHP ^7.1.3
     allow_failures:
-        - env: SYMFONY_VERSION=dev-master
+        - env: DEPENDENCIES=dev
         - php: nightly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ If you would like to implement a new feature, please submit an issue with a prop
 
 
 ## Coding Standards
+
 ### General rule
 When contributing code to this bundle, you must follow the [Symfony coding standards][2]. To make a long story short, here is the golden rule: Imitate the existing Symfony code.
 Most open-source Bundles and libraries used by Symfony also follow the same guidelines, and you should too.  
@@ -49,9 +50,11 @@ public function randomMethod(array $config, LoggerInterface $logger) : bool
 ```
 
 ## Testing
+
 ### PHPUnit
 Though we have Travis running tests on every push you do, it would be nice to make sure you run PHPUnit locally before push to upstream.  
-The easiest way to run tests is to execute this in project root directory - `vendor/bin/phpunit`
+The easiest way to run tests is to execute this in project root directory - `vendor/bin/simple-phpunit`
+
 ### Infection PHP
 For now we can not include Infection PHP in the repo, because some Symfony 2.7 dependencies are not compatible with Infection. 
 But you can always install Infection globally and run it for project with:

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
     "psr/log":                      "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit":    "~6.1",
-    "symfony/twig-bundle":"~2.7|~3.0|~4.0",
-    "symfony/var-dumper": "~2.7|~3.0|~4.0"
+    "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",
+    "symfony/twig-bundle":    "~2.7|~3.0|~4.0",
+    "symfony/var-dumper":     "~2.7|~3.0|~4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/DataCollector/HttpDataCollector.php
+++ b/src/DataCollector/HttpDataCollector.php
@@ -26,7 +26,7 @@ class HttpDataCollector extends DataCollector
 
     /**
      * @param \EightPoints\Bundle\GuzzleBundle\Log\LoggerInterface $logger
-     * @param float|int $slowResponseTime
+     * @param float|int $slowResponseTime Time in seconds
      *
      * @TODO: remove in v8, PR #228
      */


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | no
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | -
| License          | MIT

What was changed:
- Replace `hpunit/phpunit` with `symfony/phpunit-bridge` - it will give us additional information during the tests. For example when some deprecations appeared.
- Write test for data collector with slow requests
- Improve travis build - added validation of composer.json, etc.