### PR TITLE
Wrong cookies option definition

### DIFF
--- a/src/Resources/doc/configuration-reference.md
+++ b/src/Resources/doc/configuration-reference.md
@@ -91,7 +91,7 @@ eight_points_guzzle:
                 
                 stream: false
                 
-                cookies: '/path/to/file'
+                cookies: false
                 
                 proxy: 'tcp://localhost:8125'
                 


### PR DESCRIPTION
Is a bool value not string whit a path

| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | [comma-separated list of tickets fixed by the PR, if any]
| License          | MIT
