### PR TITLE
composer require-dev and suggest symfony/asset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,14 @@
     "psr/log":                      "~1.0"
   },
   "require-dev": {
+    "symfony/asset":          "~2.7|~3.0|~4.0",
     "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",
     "symfony/twig-bundle":    "~2.7|~3.0|~4.0",
     "symfony/var-dumper":     "~2.7|~3.0|~4.0",
     "symfony/yaml":           "~2.7|~3.0|~4.0"
+  },
+  "suggest": {
+    "symfony/asset": "For using the AssetExtension"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| License          | MIT


I have console application, and Idebug it using controller available in only in dev enviroment
So I've catched such exception
```
Did you forget to run "composer require symfony/asset"? Unknown function "asset".
vendor/eightpoints/guzzle-bundle/src/Resources/views/debug.html.twig (line 11)
```
So this pr must fix it )