### PR TITLE
Allow vendors deprecations in tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
 >
 	<php>
 		<env name="SYMFONY_PHPUNIT_VERSION" value="6.5" />
+		<env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
 	</php>
 
 	<testsuites>


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| License          | MIT


From symfony documentation (https://symfony.com/doc/current/components/phpunit_bridge.html):

> By using SYMFONY_DEPRECATIONS_HELPER=max[self]=0, deprecations that are triggered outside the vendors directory will be accounted for seperately, while deprecations triggered from a library inside it will not (unless you reach 999999 of these), giving you the best of both worlds.