### PR TITLE
Print Curl command for debugging purposes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,11 @@
     "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",
     "symfony/twig-bundle":    "~2.7|~3.0|~4.0",
     "symfony/var-dumper":     "~2.7|~3.0|~4.0",
-    "symfony/yaml":           "~2.7|~3.0|~4.0"
+    "symfony/yaml":           "~2.7|~3.0|~4.0",
+    "namshi/cuzzle":          "^2.0"
+  },
+  "suggest": {
+    "namshi/cuzzle": "Outputs Curl command on profiler's page for debugging purposes"
   },
   "autoload": {
     "psr-4": {

--- a/src/Log/LogMessage.php
+++ b/src/Log/LogMessage.php
@@ -19,6 +19,9 @@ class LogMessage
     /** @var null|float */
     protected $transferTime;
 
+    /** @var null|string */
+    protected $curlCommand;
+
     /**
      * @param string $message
      */
@@ -117,5 +120,21 @@ class LogMessage
     public function setTransferTime($transferTime)
     {
         $this->transferTime = $transferTime;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getCurlCommand()
+    {
+        return $this->curlCommand;
+    }
+
+    /**
+     * @param string $curlCommand
+     */
+    public function setCurlCommand($curlCommand)
+    {
+        $this->curlCommand = $curlCommand;
     }
 }

--- a/src/Log/Logger.php
+++ b/src/Log/Logger.php
@@ -2,6 +2,7 @@
 
 namespace EightPoints\Bundle\GuzzleBundle\Log;
 
+use Namshi\Cuzzle\Formatter\CurlFormatter;
 use Psr\Log\LoggerTrait;
 
 class Logger implements LoggerInterface
@@ -35,6 +36,10 @@ class Logger implements LoggerInterface
         if (!empty($context)) {
             if (!empty($context['request'])) {
                 $logMessage->setRequest(new LogRequest($context['request']));
+
+                if (class_exists(CurlFormatter::class)) {
+                    $logMessage->setCurlCommand((new CurlFormatter())->format($context['request']));
+                }
             }
 
             if (!empty($context['response'])) {

--- a/src/Resources/views/profiler.html.twig
+++ b/src/Resources/views/profiler.html.twig
@@ -67,6 +67,15 @@
                                         <textarea readonly class="format-json">{{ message.request.body }}</textarea>
                                     </td>
                                 </tr>
+
+                                {% if message.curlCommand %}
+                                <tr>
+                                    <th>Curl command</th>
+                                    <td>
+                                        <pre>{{ message.curlCommand }}</pre>
+                                    </td>
+                                </tr>
+                                {%  endif %}
                             </table>
                         </div>
 

--- a/tests/Log/LoggerTest.php
+++ b/tests/Log/LoggerTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
 use Psr\Log\LogLevel;
 
 class LoggerTest extends TestCase
@@ -64,16 +65,21 @@ class LoggerTest extends TestCase
             $this->assertNull($message->getResponse());
         }
 
+        $requestMock = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $uriMock = $this->getMockBuilder(Uri::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $requestMock = $this->getMockBuilder(Request::class)
+        $bodyMock = $this->getMockBuilder(StreamInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $requestMock->method('getHeaders')->willReturn([]);
         $requestMock->method('getUri')->willReturn($uriMock);
+        $requestMock->method('getBody')->willReturn($bodyMock);
 
         $logger->log(LogLevel::INFO, 'info message', ['request' => $requestMock]);
 


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | no
| New feature      | yes
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | #266 
| License          | MIT

Now you can run request out of Symfony's context.
![image](https://user-images.githubusercontent.com/4598274/65680569-80408780-e057-11e9-9018-74555bbbf34c.png)

**Note:** It does not require `namshi/cuzzle` vendor, but the curl command will appear only if you have it installed, added to the suggested vendors.