### PR TITLE
Rename EightPointsGuzzleBundlePlugin to follow PSR

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,7 +21,7 @@ class Configuration implements ConfigurationInterface
     protected $debug;
 
     /**
-     * @var \EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin[]
+     * @var \EightPoints\Bundle\GuzzleBundle\PluginInterface[]
      */
     protected $plugins;
 

--- a/src/DependencyInjection/EightPointsGuzzleExtension.php
+++ b/src/DependencyInjection/EightPointsGuzzleExtension.php
@@ -15,11 +15,11 @@ use GuzzleHttp\HandlerStack;
 
 class EightPointsGuzzleExtension extends Extension
 {
-    /** @var \EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin[] */
+    /** @var \EightPoints\Bundle\GuzzleBundle\PluginInterface[] */
     protected $plugins;
 
     /**
-     * @param \EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin[] $plugins
+     * @param \EightPoints\Bundle\GuzzleBundle\PluginInterface[] $plugins
      */
     public function __construct(array $plugins = [])
     {

--- a/src/EightPointsGuzzleBundle.php
+++ b/src/EightPointsGuzzleBundle.php
@@ -11,11 +11,11 @@ use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class EightPointsGuzzleBundle extends Bundle
 {
-    /** @var \EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin[] */
+    /** @var \EightPoints\Bundle\GuzzleBundle\PluginInterface[] */
     protected $plugins = [];
 
     /**
-     * @param \EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin[] $plugins
+     * @param \EightPoints\Bundle\GuzzleBundle\PluginInterface[] $plugins
      */
     public function __construct(array $plugins = [])
     {
@@ -69,13 +69,13 @@ class EightPointsGuzzleBundle extends Bundle
     }
 
     /**
-     * @param \EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin $plugin
-     *
-     * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @param \EightPoints\Bundle\GuzzleBundle\PluginInterface $plugin
      *
      * @return void
+     *@throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     *
      */
-    protected function registerPlugin(EightPointsGuzzleBundlePlugin $plugin)
+    protected function registerPlugin(PluginInterface $plugin)
     {
         // Check plugins name duplication
         foreach ($this->plugins as $registeredPlugin) {

--- a/src/PluginInterface.php
+++ b/src/PluginInterface.php
@@ -6,7 +6,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-interface EightPointsGuzzleBundlePlugin
+interface PluginInterface
 {
     /**
      * The name of this plugin. It will be used as the configuration key.

--- a/src/Resources/doc/how-to-create-a-single-file-plugin.md
+++ b/src/Resources/doc/how-to-create-a-single-file-plugin.md
@@ -101,13 +101,13 @@ Create plugin file:
 
 namespace App\GuzzlePlugin;
 
-use EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin;
+use EightPoints\Bundle\GuzzleBundle\PluginInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MagicHeaderPlugin extends Bundle implements EightPointsGuzzleBundlePlugin
+class MagicHeaderPlugin extends Bundle implements PluginInterface
 {
     /**
      * @return string
@@ -147,7 +147,7 @@ class MagicHeaderPlugin extends Bundle implements EightPointsGuzzleBundlePlugin
 }
 ```
 
-Note that we implemented `EightPointsGuzzleBundlePlugin` interface and defined 4 methods:
+Note that we implemented `PluginInterface` interface and defined 4 methods:
 - `load` - used to load xml/yaml/etc configuration
 - `loadForClient` - called after clients services are defined in container builder
 - `addConfiguration` - called when configuration tree of Guzzle Bundle is being built
@@ -158,7 +158,7 @@ First define plugin name:
 ```php
 // ...
 
-class MagicHeaderPlugin extends Bundle implements EightPointsGuzzleBundlePlugin
+class MagicHeaderPlugin extends Bundle implements PluginInterface
 {    
     /**
      * @return string
@@ -177,7 +177,7 @@ Next add possibility to configure `header_value` value in configuration file:
 ```php
 // ...
 
-class MagicHeaderPlugin extends Bundle implements EightPointsGuzzleBundlePlugin
+class MagicHeaderPlugin extends Bundle implements PluginInterface
 {
     // ...
 
@@ -250,7 +250,7 @@ Having the value of `header_value` option provided from configuration file we ca
 use Symfony\Component\ExpressionLanguage\Expression;
 use App\GuzzleMiddleware\MagicHeaderMiddleware;
 
-class MagicHeaderPlugin extends Bundle implements EightPointsGuzzleBundlePlugin
+class MagicHeaderPlugin extends Bundle implements PluginInterface
 {
     // ...
     

--- a/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
+++ b/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
@@ -4,8 +4,8 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests\DependencyInjection;
 
 use EightPoints\Bundle\GuzzleBundle\DependencyInjection\Configuration;
 use EightPoints\Bundle\GuzzleBundle\DependencyInjection\EightPointsGuzzleExtension;
-use EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin;
 use EightPoints\Bundle\GuzzleBundle\Log\DevNullLogger;
+use EightPoints\Bundle\GuzzleBundle\PluginInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -258,7 +258,7 @@ class EightPointsGuzzleExtensionTest extends TestCase
 
     public function testLoadWithPlugin()
     {
-        $plugin = $this->createMock(EightPointsGuzzleBundlePlugin::class);
+        $plugin = $this->createMock(PluginInterface::class);
         $plugin->method('getPluginName')
             ->willReturn('test');
 
@@ -291,7 +291,7 @@ class EightPointsGuzzleExtensionTest extends TestCase
 
     public function testLoadWithoutPlugin()
     {
-        $plugin = $this->createMock(EightPointsGuzzleBundlePlugin::class);
+        $plugin = $this->createMock(PluginInterface::class);
         $plugin->method('getPluginName')
             ->willReturn('test');
 

--- a/tests/EightPointsGuzzleBundleTest.php
+++ b/tests/EightPointsGuzzleBundleTest.php
@@ -5,7 +5,7 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests;
 use EightPoints\Bundle\GuzzleBundle\DependencyInjection\Compiler\EventHandlerCompilerPass;
 use EightPoints\Bundle\GuzzleBundle\DependencyInjection\EightPointsGuzzleExtension;
 use EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundle;
-use EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin;
+use EightPoints\Bundle\GuzzleBundle\PluginInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -21,7 +21,7 @@ class EightPointsGuzzleBundleTest extends TestCase
 
     public function testInitWithPlugin()
     {
-        $plugin = $this->getMockBuilder(EightPointsGuzzleBundlePlugin::class)->getMock();
+        $plugin = $this->getMockBuilder(PluginInterface::class)->getMock();
 
         new EightPointsGuzzleBundle([$plugin]);
 
@@ -33,12 +33,12 @@ class EightPointsGuzzleBundleTest extends TestCase
     {
         $this->expectException(InvalidConfigurationException::class);
 
-        $firstPlugin = $this->getMockBuilder(EightPointsGuzzleBundlePlugin::class)->getMock();
+        $firstPlugin = $this->getMockBuilder(PluginInterface::class)->getMock();
         $firstPlugin->expects($this->once())
             ->method('getPluginName')
             ->willReturn('wsse');
 
-        $secondPlugin = $this->getMockBuilder(EightPointsGuzzleBundlePlugin::class)->getMock();
+        $secondPlugin = $this->getMockBuilder(PluginInterface::class)->getMock();
         $secondPlugin->expects($this->exactly(2))
             ->method('getPluginName')
             ->willReturn('wsse');
@@ -48,7 +48,7 @@ class EightPointsGuzzleBundleTest extends TestCase
 
     public function testBoot()
     {
-        $plugin = $this->getMockBuilder(EightPointsGuzzleBundlePlugin::class)->getMock();
+        $plugin = $this->getMockBuilder(PluginInterface::class)->getMock();
         $plugin->expects($this->once())->method('boot');
 
         $bundle = new EightPointsGuzzleBundle([$plugin]);
@@ -59,7 +59,7 @@ class EightPointsGuzzleBundleTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $plugin = $this->getMockBuilder(EightPointsGuzzleBundlePlugin::class)->getMock();
+        $plugin = $this->getMockBuilder(PluginInterface::class)->getMock();
         $plugin->expects($this->once())->method('build');
 
         $bundle = new EightPointsGuzzleBundle([$plugin]);


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | no
| New feature      | no
| BC breaks        | yes
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | #178
| License          | MIT

@florianpreusner what do you think about `PluginInterface` instead of long `EightPointsGuzzleBundlePluginInterface`?