### PR TITLE
Allow to enable/disable logging on a specific client

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ eight_points_guzzle:
 
         crm:
             base_url: 'http://api.crm.tld'
-            options:            
+            options:
                 headers:
                     Accept: 'application/json'
 
@@ -158,7 +158,7 @@ For projects that use [autowiring][18], please refer to [our documentation on au
 This bundle allows to register and integrate plugins to extend functionality of guzzle and this bundle.
 
 ### Installation
- 
+
 In order to install a plugin, find the following lines in `src/Kernel.php`:
 
 ```php
@@ -199,7 +199,7 @@ foreach ($contents as $class => $envs) {
 
 This bundle dispatches Symfony events right before a client makes a call and right after a client has made a call.
 There are two types of events dispatched every time; a _generic_ event, that is dispatched regardless of which client is doing the request,
-and a _client specific_ event, that is dispatched only to listeners specifically subscribed to events from a specific client. 
+and a _client specific_ event, that is dispatched only to listeners specifically subscribed to events from a specific client.
 These events can be used to intercept requests to a remote system as well as responses from a remote system.
 In case a generic event listener and a client specific event listener both change a request/response, the changes from the client
 specific listener override those of the generic listener in case of a collision (both setting the same header for example).
@@ -217,11 +217,11 @@ services:
             - { name: 'kernel.event_listener', event: 'eight_points_guzzle.pre_transaction', method: 'onPreTransaction' }
             # Listen for client specific pre transaction events (will only receive events for the "payment" client)
             - { name: 'kernel.event_listener', event: 'eight_points_guzzle.pre_transaction.payment', method: 'onPrePaymentTransaction' }
-            
+
             - # Listen for generic post transaction event (will receive events for all clients)
             - { name: 'kernel.event_listener', event: 'eight_points_guzzle.post_transaction', method: 'onPostTransaction' }
             # Listen for client specific post transaction events (will only receive events for the "payment" client)
-            - { name: 'kernel.event_listener', event: 'eight_points_guzzle.post_transaction.payment', method: 'onPostPaymentTransaction' } 
+            - { name: 'kernel.event_listener', event: 'eight_points_guzzle.post_transaction.payment', method: 'onPostPaymentTransaction' }
 ```
 
 For more information, read the docs on [intercepting requests and responses](src/Resources/doc/intercept-request-and-response.md).

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@
 namespace EightPoints\Bundle\GuzzleBundle\DependencyInjection;
 
 use function method_exists;
+use EightPoints\Bundle\GuzzleBundle\Log\Logger;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -102,6 +103,20 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->booleanNode('lazy')->defaultValue(false)->end()
+                    ->integerNode('logging')
+                        ->defaultValue(null)
+                        ->beforeNormalization()
+                            ->always(function ($value): int {
+                                if ($value === 1 || $value === true) {
+                                    return Logger::LOG_MODE_REQUEST_AND_RESPONSE;
+                                } elseif ($value === 0 || $value === false) {
+                                    return Logger::LOG_MODE_NONE;
+                                } else {
+                                    return constant(Logger::class .'::LOG_MODE_' . strtoupper($value));
+                                }
+                            })
+                        ->end()
+                    ->end()
                     ->scalarNode('handler')
                         ->defaultValue(null)
                         ->validate()

--- a/src/Log/LogResponse.php
+++ b/src/Log/LogResponse.php
@@ -2,6 +2,7 @@
 
 namespace EightPoints\Bundle\GuzzleBundle\Log;
 
+use EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundle;
 use Psr\Http\Message\ResponseInterface;
 
 class LogResponse
@@ -21,11 +22,16 @@ class LogResponse
     /** @var string */
     protected $protocolVersion;
 
+    /** @var bool */
+    private $logBody;
+
     /**
      * @param \Psr\Http\Message\ResponseInterface $response
+     * @param bool $logBody
      */
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, bool $logBody = true)
     {
+        $this->logBody = $logBody;
         $this->save($response);
     }
 
@@ -40,15 +46,20 @@ class LogResponse
     {
         $this->setStatusCode($response->getStatusCode());
         $this->setStatusPhrase($response->getReasonPhrase());
-        $this->setBody($response->getBody()->getContents());
-
-        // rewind to previous position after reading response body
-        if ($response->getBody()->isSeekable()) {
-            $response->getBody()->rewind();
-        }
 
         $this->setHeaders($response->getHeaders());
         $this->setProtocolVersion($response->getProtocolVersion());
+
+        if ($this->logBody) {
+            $this->setBody($response->getBody()->getContents());
+
+            // rewind to previous position after reading response body
+            if ($response->getBody()->isSeekable()) {
+                $response->getBody()->rewind();
+            }
+        } else {
+            $this->setBody(EightPointsGuzzleBundle::class . ': [response body log disabled]');
+        }
     }
 
     /**

--- a/src/Resources/doc/configuration-reference.md
+++ b/src/Resources/doc/configuration-reference.md
@@ -14,23 +14,26 @@ eight_points_guzzle:
 eight_points_guzzle:
     # (de)activate logging; default: %kernel.debug%
     logging: true
-    
+
     # (de)activate profiler; default: %kernel.debug%
     profiling: true
-    
+
     # configure when a response is considered to be slow (in ms); default 0 (disabled)
     slow_response_time: 500
 
     clients:
         api_payment:
             base_url: "http://api.domain.tld"
-            
+
             # Read more here: https://github.com/8p/EightPointsGuzzleBundle/blob/master/src/Resources/doc/redefine-client-class.md
             class: 'Namespace\Of\Your\Client\AwesomeClient'
-            
+
             # NOTE: This option makes Guzzle Client as lazy (https://symfony.com/doc/master/service_container/lazy_services.html)
             lazy: true # Default `false`
-            
+
+            # Allows to configure logging mode on a specific client
+            logging: null # Default null, possible values: null (global settings), true, false, request, request_and_response_headers
+
             # Handler class to be used for the client
             handler: 'GuzzleHttp\Handler\MockHandler'
 
@@ -42,59 +45,59 @@ eight_points_guzzle:
 
                 headers:
                     Accept: "application/json"
-                
+
                 # Find proper php const, for example CURLOPT_SSLVERSION, remove CURLOPT_ and transform to lower case.
                 # List of curl options: http://php.net/manual/en/function.curl-setopt.php
                 curl:
                     sslversion: 1 # or !php/const:CURL_HTTP_VERSION_1_0 for symfony >= 3.2
 
                 timeout: 30
-                
+
                 connect_timeout: 3.14
-                
+
                 allow_redirects: true
-                
+
                 query:
                     foo: bar
-                    
+
                 debug: true
-                
+
                 decode_content: true
-                
+
                 delay: 1000
-                
+
                 http_errors: true
-                
+
                 synchronous: false
-                
+
                 verify: true
-                
+
                 version: 1.1
-                
+
                 cert: ['/path/server.pem', 'password']
-                
+
                 form_params:
                     foo: 'bar'
                     baz: ['hi', 'there!']
-                    
+
                 multipart:
                     - name: 'foo'
                       contents: 'data'
                       headers:
                         'X-Baz' => 'bar'
-                
+
                 sink: '/path/to/file'
-                
+
                 expect: 1048576
-                
+
                 ssl_key: '/path/to/file'
-                
+
                 stream: false
-                
+
                 cookies: '/path/to/file'
-                
+
                 proxy: 'tcp://localhost:8125'
-                
+
             # plugin settings
             plugin:
                 # More information: https://packagist.org/packages/gregurco/guzzle-bundle-oauth2-plugin
@@ -104,29 +107,31 @@ eight_points_guzzle:
                     client_id:      "test-client-id"
                     client_secret:  "test-client-secret" # optional
                     scope:          "administration"
-                   
+
                 # More information: https://packagist.org/packages/gregurco/guzzle-bundle-cache-plugin
                 cache:
                     enabled: true
-                    
+
                 # More information: https://packagist.org/packages/gregurco/guzzle-bundle-wsse-plugin
                 wsse:
                     username:   "acme"
                     password:   "pa55w0rd"
                     created_at: "-10 seconds" # optional
-                    
+
                 # More information: https://packagist.org/packages/neirda24/guzzle-bundle-header-forward-plugin
                 header_forward:
                     enabled: true
                     headers:
                         - 'Accept-Language'
-                     
-                # More information: https://packagist.org/packages/neirda24/guzzle-bundle-header-disable-cache-plugin 
+
+                # More information: https://packagist.org/packages/neirda24/guzzle-bundle-header-disable-cache-plugin
                 header_disable_cache:
                     enabled: true
                     header: 'X-Guzzle-Skip-Cache' # Optional
 ```
 
 Description for all options and examples of parameters can be found [here][1].
+
+
 
 [1]: http://docs.guzzlephp.org/en/latest/request-options.html

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -60,7 +60,19 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
         $processedConfig = $processor->processConfiguration(new Configuration('eight_points_guzzle'), $config);
 
-        $this->assertEquals(array_merge($config['eight_points_guzzle'], ['logging' => false, 'profiling' => false, 'slow_response_time' => 0]), $processedConfig);
+        $this->assertEquals(array_merge_recursive(
+            $config['eight_points_guzzle'],
+            [
+                'logging' => false,
+                'profiling' => false,
+                'slow_response_time' => 0,
+                'clients' => [
+                    'test_client' => [
+                        'logging' => null,
+                    ]
+                ],
+            ]
+        ), $processedConfig);
     }
 
     public function testSingleClientConfigWithCertAsArray()
@@ -112,7 +124,19 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
         $processedConfig = $processor->processConfiguration(new Configuration('eight_points_guzzle'), $config);
 
-        $this->assertEquals(array_merge($config['eight_points_guzzle'], ['logging' => false, 'profiling' => false, 'slow_response_time' => 0]), $processedConfig);
+        $this->assertEquals(array_merge_recursive(
+            $config['eight_points_guzzle'],
+            [
+                'logging' => false,
+                'profiling' => false,
+                'slow_response_time' => 0,
+                'clients' => [
+                    'test_client' => [
+                        'logging' => null,
+                    ]
+                ],
+            ]
+        ), $processedConfig);
     }
 
     public function testInvalidCertConfiguration()
@@ -183,7 +207,7 @@ class ConfigurationTest extends TestCase
             'logging' => false,
             'profiling' => false,
             'slow_response_time' => 0,
-            'clients' => ['test_client' => ['options' => ['proxy' => ['http' => 'http://proxy.org']]]]
+            'clients' => ['test_client' => ['logging' => null, 'options' => ['proxy' => ['http' => 'http://proxy.org']]]]
         ]), $processedConfig);
     }
 

--- a/tests/Log/LogResponseTest.php
+++ b/tests/Log/LogResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace EightPoints\Bundle\GuzzleBundle\Tests\Log;
 
+use EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundle;
 use EightPoints\Bundle\GuzzleBundle\Log\LogResponse;
 use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Psr7\Response;
@@ -55,6 +56,13 @@ class LogResponseTest extends TestCase
         $response = new LogResponse($this->response);
 
         $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testBodyLoggingDisabled()
+    {
+        $response = new LogResponse($this->response, false);
+
+        $this->assertSame(EightPointsGuzzleBundle::class . ': [response body log disabled]', $response->getBody());
     }
 
     /**

--- a/tests/Middleware/RequestTimeMiddlewareTest.php
+++ b/tests/Middleware/RequestTimeMiddlewareTest.php
@@ -19,13 +19,12 @@ class RequestTimeMiddlewareTest extends TestCase
     public function setUp()
     {
         $this->logger = $this->getMockBuilder(Logger::class)
-            ->disableOriginalConstructor()
             ->getMock();
     }
 
     public function testInvoke()
     {
-        $httpDataCollector = new HttpDataCollector($this->logger, 0);
+        $httpDataCollector = new HttpDataCollector([$this->logger], 0);
 
         $request = new Request('GET', 'http://test.com');
         $handler = new MockHandler([new Response(200)]);
@@ -47,7 +46,7 @@ class RequestTimeMiddlewareTest extends TestCase
 
     public function testInvokeWithInitialOnStats()
     {
-        $httpDataCollector = new HttpDataCollector($this->logger, 0);
+        $httpDataCollector = new HttpDataCollector([$this->logger], 0);
 
         $request = new Request('GET', 'http://test.com');
         $handler = new MockHandler([new Response(200)]);


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | yes
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | related to https://github.com/8p/EightPointsGuzzleBundle/issues/48 https://github.com/8p/EightPointsGuzzleBundle/issues/32
| License          | MIT


This PR allows to enable/disable logging on a specific client, mainly because the stream rewinding still does not work on particular cases (continuous event streaming as example).