### PR TITLE
Upgrading PHP to 7.2 and two small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-    - 7.1
     - 7.2
     - 7.3
     - nightly

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     }
   ],
   "require": {
-    "php":                          ">=7.1",
+    "php":                          ">=7.2",
     "guzzlehttp/guzzle":            "~6.0",
     "symfony/framework-bundle":     "~4.0|~5.0",
     "symfony/expression-language":  "~4.0|~5.0",

--- a/src/PluginInterface.php
+++ b/src/PluginInterface.php
@@ -51,7 +51,7 @@ interface PluginInterface
      *
      * @return void
      */
-    public function build(ContainerBuilder $container) : void;
+    public function build(ContainerBuilder $container);
 
     /**
      * When the bundles are booted, you can do any runtime initialization required inside this method.

--- a/src/PluginInterface.php
+++ b/src/PluginInterface.php
@@ -58,5 +58,5 @@ interface PluginInterface
      *
      * @return void
      */
-    public function boot() : void;
+    public function boot();
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | yes
| Deprecations     | yes
| Tests pass       | yes
| Fixed tickets    | -
| License          | MIT

I had to upgrade the PHP version to 7.2 because it was breaking when I used with Symfony components in v. 5. Since this may be an issue for others too and PHP 7.1 reached EOL I'm sending all the changes I did to make it happen:

 - Shifted the version within the `composer.json`
 - Changed the method signature of `EightPointsGuzzleBundlePlugin::build` and `EightPointsGuzzleBundlePlugin::boot` to match the new ones inside the `symfony/http-kernel` component.

I also know that perhaps this is not a so common scenario, but raising this discussion won't hurt anyone.

Thanks!