### PR TITLE
Fix compatibility with HTTP Kernel bundle type hints

### DIFF
--- a/src/PluginInterface.php
+++ b/src/PluginInterface.php
@@ -48,15 +48,11 @@ interface PluginInterface
      * When the container is generated for the first time, you can register compiler passes inside this method.
      *
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @return void
      */
-    public function build(ContainerBuilder $container) : void;
+    public function build(ContainerBuilder $container);
 
     /**
      * When the bundles are booted, you can do any runtime initialization required inside this method.
-     *
-     * @return void
      */
-    public function boot() : void;
+    public function boot();
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | #297
| License          | MIT

Interface should be compatible with types from here: https://github.com/symfony/http-kernel/blob/v5.0.4/Bundle/Bundle.php#L37