### PR TITLE
Added service aliases to allow easier autowiring

### DIFF
--- a/src/DependencyInjection/EightPointsGuzzleExtension.php
+++ b/src/DependencyInjection/EightPointsGuzzleExtension.php
@@ -94,11 +94,11 @@ class EightPointsGuzzleExtension extends Extension
             $container->setDefinition($serviceName, $client);
 
             // Allowed only for Symfony 4.2+
-            if (\method_exists($container, 'registerAliasForArgument')) {
-                if ('%eight_points_guzzle_bundle.http_client.class%' !== $options['class']) {
-                    $container->registerAliasForArgument($serviceName, $options['class'], $name.'Client');
+            if (method_exists($container, 'registerAliasForArgument')) {
+                if ('%eight_points_guzzle.http_client.class%' !== $options['class']) {
+                    $container->registerAliasForArgument($serviceName, $options['class'], $name . 'Client');
                 }
-                $container->registerAliasForArgument($serviceName, ClientInterface::class, $name.'Client');
+                $container->registerAliasForArgument($serviceName, ClientInterface::class, $name . 'Client');
             }
         }
 

--- a/src/Resources/doc/autowiring-clients.md
+++ b/src/Resources/doc/autowiring-clients.md
@@ -4,6 +4,44 @@ Autowiring was introduced in Symfony 3.3 and let's read how [Symfony Documentati
 
 > Autowiring allows you to manage services in the container with minimal configuration. It reads the type-hints on your constructor (or other methods) and automatically passes the correct services to each method. Symfony's autowiring is designed to be predictable: if it is not absolutely clear which dependency should be passed, you'll see an actionable exception.
 
+## Symfony >= 4.2
+In Symfony 4.2, it is made possible to [bind services by type and name](https://symfony.com/blog/new-in-symfony-4-2-autowiring-by-type-and-name). This feature makes using Guzzle clients a lot easier. Given the following configuration:
+
+```yaml
+eight_points_guzzle:
+    clients:
+        api_payment:
+            base_url: "http://api.domain1.tld"
+        api_crm:
+            class: App\Client\ApiCrmClient
+            base_url: "http://api.domain2.tld"
+```
+The clients can be autowired without further configuration (but mandatory variable names), like this:
+
+```php
+namespace App\Controller;
+
+use GuzzleHttp\ClientInterface;
+use App\Client\ApiCrmClient;
+
+class FooController extends AbstractController
+{
+    public function bar(ClientInterface $apiPaymentClient)
+    {
+        // Default Client class    
+    }
+
+    public function baz(ApiCrmClient $apiCrmClient)
+    {
+        // Custom Client class (must extend GuzzleHttp\Client)    
+    }
+}
+```
+
+Autowiring takes place by the combination of the class name and the variable name, as described in [this blog].
+
+## Symfony < 4.2
+
 Getting in consideration, that Guzzle Bundle creates clients of same class, it becomes obvious that Symfony will not be able to guess what to inject.
 With some small configurations we can help Symfony to do it. 
 

--- a/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
+++ b/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
@@ -34,9 +34,11 @@ class EightPointsGuzzleExtensionTest extends TestCase
         $this->assertInstanceOf(Client::class, $testApi);
         $this->assertEquals(new Uri('//api.domain.tld/path'), $testApi->getConfig('base_uri'));
 
-        if (method_exists($container, 'hasAlias')) {
+        if (method_exists($container, 'registerAliasForArgument')) {
             $this->assertTrue($container->hasAlias(ClientInterface::class . ' $testApiClient'));
             $this->assertSame($testApi, $container->get(ClientInterface::class . ' $testApiClient'));
+
+            $this->assertFalse($container->hasAlias('%eight_points_guzzle.http_client.class% $testApiClient'));
         }
 
         // test Services
@@ -47,7 +49,7 @@ class EightPointsGuzzleExtensionTest extends TestCase
         $definition = $container->getDefinition('eight_points_guzzle.client.test_api_with_custom_class');
         $this->assertSame(CustomClient::class, $definition->getClass());
 
-        if (method_exists($container, 'hasAlias')) {
+        if (method_exists($container, 'registerAliasForArgument')) {
             $testApi = $container->get('eight_points_guzzle.client.test_api_with_custom_class');
             $this->assertTrue($container->hasAlias(CustomClient::class . ' $testApiWithCustomClassClient'));
             $this->assertSame($testApi, $container->get(ClientInterface::class . ' $testApiWithCustomClassClient'));

--- a/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
+++ b/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
@@ -34,6 +34,9 @@ class EightPointsGuzzleExtensionTest extends TestCase
         $this->assertInstanceOf(Client::class, $testApi);
         $this->assertEquals(new Uri('//api.domain.tld/path'), $testApi->getConfig('base_uri'));
 
+        $this->assertTrue($container->hasAlias(ClientInterface::class.' $testApiClient'));
+        $this->assertSame($testApi, $container->get(ClientInterface::class.' $testApiClient'));
+
         // test Services
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.event_dispatch.test_api'));
 
@@ -42,6 +45,9 @@ class EightPointsGuzzleExtensionTest extends TestCase
         $definition = $container->getDefinition('eight_points_guzzle.client.test_api_with_custom_class');
         $this->assertSame(CustomClient::class, $definition->getClass());
 
+        $testApi = $container->get('eight_points_guzzle.client.test_api_with_custom_class');
+        $this->assertTrue($container->hasAlias(CustomClient::class.' $testApiWithCustomClassClient'));
+        $this->assertSame($testApi, $container->get(ClientInterface::class.' $testApiWithCustomClassClient'));
 
         // test Client with custom handler
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.client.test_api_with_custom_handler'));

--- a/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
+++ b/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
@@ -34,8 +34,10 @@ class EightPointsGuzzleExtensionTest extends TestCase
         $this->assertInstanceOf(Client::class, $testApi);
         $this->assertEquals(new Uri('//api.domain.tld/path'), $testApi->getConfig('base_uri'));
 
-        $this->assertTrue($container->hasAlias(ClientInterface::class.' $testApiClient'));
-        $this->assertSame($testApi, $container->get(ClientInterface::class.' $testApiClient'));
+        if (method_exists($container, 'hasAlias')) {
+            $this->assertTrue($container->hasAlias(ClientInterface::class . ' $testApiClient'));
+            $this->assertSame($testApi, $container->get(ClientInterface::class . ' $testApiClient'));
+        }
 
         // test Services
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.middleware.event_dispatch.test_api'));
@@ -45,9 +47,11 @@ class EightPointsGuzzleExtensionTest extends TestCase
         $definition = $container->getDefinition('eight_points_guzzle.client.test_api_with_custom_class');
         $this->assertSame(CustomClient::class, $definition->getClass());
 
-        $testApi = $container->get('eight_points_guzzle.client.test_api_with_custom_class');
-        $this->assertTrue($container->hasAlias(CustomClient::class.' $testApiWithCustomClassClient'));
-        $this->assertSame($testApi, $container->get(ClientInterface::class.' $testApiWithCustomClassClient'));
+        if (method_exists($container, 'hasAlias')) {
+            $testApi = $container->get('eight_points_guzzle.client.test_api_with_custom_class');
+            $this->assertTrue($container->hasAlias(CustomClient::class . ' $testApiWithCustomClassClient'));
+            $this->assertSame($testApi, $container->get(ClientInterface::class . ' $testApiWithCustomClassClient'));
+        }
 
         // test Client with custom handler
         $this->assertTrue($container->hasDefinition('eight_points_guzzle.client.test_api_with_custom_handler'));


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | no
| New feature      | yes
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | --
| License          | MIT

Since Symfony 4.2, it is possible to create [service aliases by class name and attribute](https://symfony.com/blog/new-in-symfony-4-2-autowiring-by-type-and-name). Inspired by the feature to [auto-wire specific monolog channels](https://github.com/symfony/monolog-bundle/pull/315) I have created this pull request to make it easier to auto-wire Guzzle-clients.