### PR TITLE
Fixed a very minor typo in the Intercept Request/Response documentation

### DIFF
--- a/src/Resources/doc/intercept-request-and-response.md
+++ b/src/Resources/doc/intercept-request-and-response.md
@@ -79,7 +79,7 @@ Let's subscribe our service to one more event:
 
 ```yaml
 services:
-    App\EventListener\PartnersApiGuzzleEventListener:
+    App\EventListener\PaymentApiGuzzleEventListener:
         class: App\EventListener\PaymentApiGuzzleEventListener
         tags:
             - { name: kernel.event_listener, event: eight_points_guzzle.pre_transaction.payment, method: onPreTransaction }
@@ -179,8 +179,8 @@ And configure the Symfony service as usual for event subscribers:
 
 ```yaml
 services:
-    App\EventSubscriber\PartnersApiGuzzleEventSubscriber:
-        class: App\EventSubscriber\PartnersApiGuzzleEventSubscriber
+    App\EventSubscriber\PaymentApiGuzzleEventSubscriber:
+        class: App\EventSubscriber\PaymentApiGuzzleEventSubscriber
         tags:
             - { name: kernel.event_subscriber }
 ```

--- a/src/Resources/doc/intercept-request-and-response.md
+++ b/src/Resources/doc/intercept-request-and-response.md
@@ -56,7 +56,7 @@ For that we need to register it in the Symfony configuration as an event listene
 
 ```yaml
 services:
-    App\EventListener\PartnersApiGuzzleEventListener:
+    App\EventListener\PaymentApiGuzzleEventListener:
         class: App\EventListener\PaymentApiGuzzleEventListener
         tags:       
             - { name: kernel.event_listener, event: eight_points_guzzle.pre_transaction.payment, method: onPreTransaction }


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | Documentation fix
| License          | MIT

Implementing this into a new project and realized there's a minor fix in the documentation required for the interceptor.