### PR TITLE
Process Throwable reason without useless TypeError

### DIFF
--- a/src/Middleware/EventDispatchMiddleware.php
+++ b/src/Middleware/EventDispatchMiddleware.php
@@ -6,7 +6,7 @@ use EightPoints\Bundle\GuzzleBundle\Events\Event;
 use EightPoints\Bundle\GuzzleBundle\Events\GuzzleEvents;
 use EightPoints\Bundle\GuzzleBundle\Events\PostTransactionEvent;
 use EightPoints\Bundle\GuzzleBundle\Events\PreTransactionEvent;
-use Exception;
+use Throwable;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -70,7 +70,7 @@ class EventDispatchMiddleware
                         // Continue down the chain.
                         return $postTransactionEvent->getTransaction();
                     },
-                    function (Exception $reason) {
+                    function (Throwable $reason) {
                         // Get the response. The response in a RequestException can be null too.
                         $response = $reason instanceof RequestException ? $reason->getResponse() : null;
 


### PR DESCRIPTION
Goes from error "TypeError
Argument 1 passed to EightPoints\Bundle\
GuzzleBundle\Middleware\EventDispatchMiddleware::
EightPoints\Bundle\GuzzleBundle\Middleware\
{closure}() must be an instance of Exception,
 instance of TypeError given, called in
 /vendor/guzzlehttp/promises/src/Promise.php on line 203"

| Q                | A
| ---------------- | -----
| Bug fix          | yes
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | [comma-separated list of tickets fixed by the PR, if any]
| License          | MIT
