### PR TITLE
Fix curl options docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ eight_points_guzzle:
                 # Find proper php const, for example CURLOPT_SSLVERSION, remove CURLOPT_ and transform to lower case.
                 # List of curl options: http://php.net/manual/en/function.curl-setopt.php
                 curl:
-                    !php/const:CURL_HTTP_VERSION_1_0: 1
+                    sslversion: 1
 
                 timeout: 30
 


### PR DESCRIPTION
The key must be lowercase version of CURLOPT_SSLVERSION without the CURLOPT_. Also the `!php/const:CURL_HTTP_VERSION_1_0` syntax was invalid (shouldn't have colon after const)

| Q                | A
| ---------------- | -----
| Bug fix          | /no
| New feature      | no
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | 
| License          | MIT
