### PR TITLE
PHP 8.4 deprecations

### DIFF
--- a/src/DataCollector/DataCollectorSymfonyCompatibilityTrait.php
+++ b/src/DataCollector/DataCollectorSymfonyCompatibilityTrait.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 trait DataCollectorSymfonyCompatibilityTrait
 {
-    abstract protected function doCollect(Request $request, Response $response, \Throwable $exception = null);
+    abstract protected function doCollect(Request $request, Response $response, ?\Throwable $exception = null);
 
     /**
      * @param Request $request
@@ -16,7 +16,7 @@ trait DataCollectorSymfonyCompatibilityTrait
      *
      * @return void
      */
-    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $this->doCollect($request, $response, $exception);
     }

--- a/src/DataCollector/HttpDataCollector.php
+++ b/src/DataCollector/HttpDataCollector.php
@@ -37,7 +37,7 @@ class HttpDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    protected function doCollect(Request $request, Response $response, \Throwable $exception = null)
+    protected function doCollect(Request $request, Response $response, ?\Throwable $exception = null)
     {
         $messages = [];
         foreach ($this->loggers as $logger) {


### PR DESCRIPTION
| Q                | A
| ---------------- | -----
| Bug fix          |no
| New feature      | yes
| BC breaks        | no
| Deprecations     | no
| Tests pass       | yes
| Fixed tickets    | 
| License          | MIT

```
Implicitly marking parameter $foo as nullable is deprecated, the explicit nullable type must be used instead
```