### PR TITLE
Make bundle compatible with FrankenPHP worker mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 **[Features](#features)** |
 **[Suggestions](#suggestions)** |
 **[Contributing](#contributing)** |
+**[FrankenPHP / worker mode](#frankenphp--worker-mode)** |
 **[Learn more](#learn-more)** |
 **[License](#license)**
 
@@ -264,6 +265,11 @@ In case your project uses autowiring this suggestion does not apply.
 🎉 Thanks to all [contributors][11] who participated in this project.
 
 ----
+
+## FrankenPHP / worker mode
+
+This bundle resets in-memory log buffers and cookie jars between requests via Symfony `kernel.reset`,
+so it is safe to use with [FrankenPHP worker mode](src/Resources/doc/frankenphp-worker-mode.md) and similar long-running runtimes.
 
 ## Learn more
 - [Autowiring Clients](src/Resources/doc/autowiring-clients.md)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,14 @@
 
 This document describes the changes needed when upgrading from one version to another.
 
+## FrankenPHP / worker mode (no BC break)
+
+Logger services are tagged with `kernel.reset` and implement `Symfony\Contracts\Service\ResetInterface`.
+When `options.cookies: true` is set, a `GuzzleHttp\Cookie\CookieJar` service is injected and cleared between requests.
+No application code changes are required for this compatibility work.
+
+See [frankenphp-worker-mode.md](src/Resources/doc/frankenphp-worker-mode.md).
+
 ## Upgrading From 7.x to 8.0
 
 ### Step 1: upgrade PHP and Symfony

--- a/src/DataCollector/HttpDataCollector.php
+++ b/src/DataCollector/HttpDataCollector.php
@@ -90,6 +90,12 @@ class HttpDataCollector extends DataCollector
             'totalTime' => 0,
             'hasSlowResponse' => false,
         ];
+
+        // Also clear in-memory loggers: between requests in worker mode,
+        // kernel.reset may run without collect() having been called.
+        foreach ($this->loggers as $logger) {
+            $logger->clear();
+        }
     }
 
     /**

--- a/src/DependencyInjection/EightPointsGuzzleExtension.php
+++ b/src/DependencyInjection/EightPointsGuzzleExtension.php
@@ -5,6 +5,7 @@ namespace EightPoints\Bundle\GuzzleBundle\DependencyInjection;
 use EightPoints\Bundle\GuzzleBundle\Log\Logger;
 use EightPoints\Bundle\GuzzleBundle\Twig\Extension\DebugExtension;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Cookie\CookieJar;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -77,6 +78,13 @@ class EightPointsGuzzleExtension extends Extension
             if (isset($options['options']) && is_array($options['options'])) {
                 foreach ($options['options'] as $key => $value) {
                     if ($value === null || (is_array($value) && count($value) === 0)) {
+                        continue;
+                    }
+
+                    // When cookies=true, Guzzle would keep a CookieJar on the singleton client.
+                    // Inject a resettable jar so long-running workers (FrankenPHP) do not leak cookies.
+                    if ($key === 'cookies' && $value === true) {
+                        $argument[$key] = new Reference($this->defineCookieJar($container, $name));
                         continue;
                     }
 
@@ -219,6 +227,7 @@ class EightPointsGuzzleExtension extends Extension
         $loggerDefinition->setPublic(false);
         $loggerDefinition->setArgument(0, $logMode);
         $loggerDefinition->addTag('eight_points_guzzle.logger');
+        $loggerDefinition->addTag('kernel.reset', ['method' => 'reset']);
 
         $loggerName = sprintf('eight_points_guzzle.%s_logger', $clientName);
         $container->setDefinition($loggerName, $loggerDefinition);
@@ -387,6 +396,29 @@ class EightPointsGuzzleExtension extends Extension
         $logMiddlewareDefinition->setPublic(true);
         $logMiddlewareDefinition->addTag('monolog.logger', ['channel' => 'eight_points_guzzle']);
         $container->setDefinition('eight_points_guzzle.middleware.symfony_log', $logMiddlewareDefinition);
+    }
+
+
+    /**
+     * Define a CookieJar that is cleared between requests (worker / FrankenPHP safe).
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param string $clientName
+     *
+     * @return string service id
+     */
+    protected function defineCookieJar(ContainerBuilder $container, string $clientName) : string
+    {
+        $cookieJarServiceName = sprintf('eight_points_guzzle.cookie_jar.%s', $clientName);
+
+        if (!$container->hasDefinition($cookieJarServiceName)) {
+            $cookieJarDefinition = new Definition(CookieJar::class);
+            $cookieJarDefinition->setPublic(false);
+            $cookieJarDefinition->addTag('kernel.reset', ['method' => 'clear']);
+            $container->setDefinition($cookieJarServiceName, $cookieJarDefinition);
+        }
+
+        return $cookieJarServiceName;
     }
 
     /**

--- a/src/Log/DevNullLogger.php
+++ b/src/Log/DevNullLogger.php
@@ -3,11 +3,12 @@
 namespace EightPoints\Bundle\GuzzleBundle\Log;
 
 use Psr\Log\LoggerTrait;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author SuRiKmAn <surikman@surikman.sk>
  */
-class DevNullLogger implements LoggerInterface
+class DevNullLogger implements LoggerInterface, ResetInterface
 {
     use LoggerTrait;
 
@@ -27,6 +28,14 @@ class DevNullLogger implements LoggerInterface
     public function clear() : void
     {
         // do nothing!!
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset() : void
+    {
+        $this->clear();
     }
 
     /**

--- a/src/Log/Logger.php
+++ b/src/Log/Logger.php
@@ -4,8 +4,9 @@ namespace EightPoints\Bundle\GuzzleBundle\Log;
 
 use Namshi\Cuzzle\Formatter\CurlFormatter;
 use Psr\Log\LoggerTrait;
+use Symfony\Contracts\Service\ResetInterface;
 
-class Logger implements LoggerInterface
+class Logger implements LoggerInterface, ResetInterface
 {
     const LOG_MODE_NONE = 0;
     const LOG_MODE_REQUEST = 1;
@@ -74,6 +75,17 @@ class Logger implements LoggerInterface
     public function clear() : void
     {
         $this->messages = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Clears buffered messages so state does not leak between requests
+     * in long-running workers (e.g. FrankenPHP worker mode).
+     */
+    public function reset() : void
+    {
+        $this->clear();
     }
 
     /**

--- a/src/Resources/doc/frankenphp-worker-mode.md
+++ b/src/Resources/doc/frankenphp-worker-mode.md
@@ -1,0 +1,24 @@
+# FrankenPHP / long-running worker compatibility
+
+This bundle is compatible with [FrankenPHP](https://frankenphp.dev/) worker mode and other long-running Symfony runtimes
+(RoadRunner, Swoole, etc.) where the PHP process and the service container survive across HTTP requests.
+
+## What was fixed
+
+Symfony resets services tagged with `kernel.reset` between requests. Without that, singleton services can leak state.
+
+| Component | Behavior |
+|-----------|----------|
+| In-memory `Logger` (profiler logging) | Implements `ResetInterface` and is tagged with `kernel.reset` so buffered messages (including request/response bodies) are cleared after each request. |
+| `HttpDataCollector` | `reset()` also clears attached loggers, so state is wiped even if `collect()` did not run. |
+| `options.cookies: true` | Injects a shared `CookieJar` service tagged with `kernel.reset` (`clear`), so cookies do not leak between requests on a singleton client. |
+
+## Recommendations
+
+1. Keep `logging` / `profiling` tied to `%kernel.debug%` in production workers unless you need them; they allocate memory for each HTTP call.
+2. Prefer `options.cookies: false` (default) unless you need a cookie jar. When cookies are required, `cookies: true` is worker-safe with this bundle.
+3. Do not store request-specific data in custom Guzzle middleware registered as shared services without implementing reset.
+
+## Verification
+
+After deploying, confirm under load that memory stays stable and that authenticated upstream sessions (cookies) are not shared across unrelated Symfony requests.

--- a/tests/DataCollector/HttpDataCollectorTest.php
+++ b/tests/DataCollector/HttpDataCollectorTest.php
@@ -53,7 +53,7 @@ class HttpDataCollectorTest extends TestCase
                      ->method('getMessages')
                      ->willReturn(['test message']);
 
-        $this->logger->expects($this->once())->method('clear');
+        $this->logger->expects($this->atLeastOnce())->method('clear');
 
         $collector = new HttpDataCollector([$this->logger], 0);
         $response  = $this->getMockBuilder(Response::class)
@@ -94,8 +94,8 @@ class HttpDataCollectorTest extends TestCase
             ->method('getMessages')
             ->willReturn(['test message']);
 
-        $this->logger->expects($this->once())->method('clear');
-        $secondLogger->expects($this->once())->method('clear');
+        $this->logger->expects($this->atLeastOnce())->method('clear');
+        $secondLogger->expects($this->atLeastOnce())->method('clear');
 
         $collector = new HttpDataCollector([$this->logger, $secondLogger], 0);
         $response  = $this->getMockBuilder(Response::class)
@@ -145,7 +145,7 @@ class HttpDataCollectorTest extends TestCase
                      ->method('getMessages')
                      ->willReturn([$slowLogMessage]);
 
-        $this->logger->expects($this->once())->method('clear');
+        $this->logger->expects($this->atLeastOnce())->method('clear');
 
         $collector = new HttpDataCollector([$this->logger], 1);
 
@@ -379,6 +379,25 @@ class HttpDataCollectorTest extends TestCase
         $collector->collect($request, $response);
 
         $this->assertEquals($expectedValue, $collector->hasSlowResponses());
+    }
+
+
+    /**
+     * In worker mode, kernel.reset may run without collect().
+     *
+     * @covers \EightPoints\Bundle\GuzzleBundle\DataCollector\HttpDataCollector::reset
+     */
+    public function testResetClearsLoggersWithoutCollect()
+    {
+        $this->logger->expects($this->atLeastOnce())->method('clear');
+
+        $collector = new HttpDataCollector([$this->logger], 0);
+        $collector->addTotalTime(1.5);
+        $collector->reset();
+
+        $this->assertSame(0, $collector->getCallCount());
+        $this->assertCount(0, $collector->getLogs());
+        $this->assertEquals(0, $collector->getTotalTime());
     }
 
     public function responseTimeProvider()

--- a/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
+++ b/tests/DependencyInjection/EightPointsGuzzleExtensionTest.php
@@ -7,12 +7,14 @@ use EightPoints\Bundle\GuzzleBundle\DependencyInjection\EightPointsGuzzleExtensi
 use EightPoints\Bundle\GuzzleBundle\Log\DevNullLogger;
 use EightPoints\Bundle\GuzzleBundle\PluginInterface;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use PHPUnit\Framework\TestCase;
@@ -421,6 +423,43 @@ class EightPointsGuzzleExtensionTest extends TestCase
     /**
      * @see https://github.com/8p/EightPointsGuzzleBundle/issues/235
      */
+
+    public function testLoggerHasKernelResetTag()
+    {
+        $container = $this->createContainer();
+        $extension = new EightPointsGuzzleExtension();
+        $config = $this->getConfigs();
+        $config[0]['logging'] = true;
+        $extension->load($config, $container);
+
+        $loggerDefinition = $container->getDefinition('eight_points_guzzle.test_api_logger');
+        $this->assertTrue($loggerDefinition->hasTag('kernel.reset'));
+        $this->assertSame([['method' => 'reset']], $loggerDefinition->getTag('kernel.reset'));
+    }
+
+    public function testCookiesTrueInjectsResettableCookieJar()
+    {
+        $container = $this->createContainer();
+        $extension = new EightPointsGuzzleExtension();
+        $config = $this->getConfigs();
+        $config[0]['clients']['test_api']['options']['cookies'] = true;
+        $extension->load($config, $container);
+
+        $this->assertTrue($container->hasDefinition('eight_points_guzzle.cookie_jar.test_api'));
+        $cookieJarDefinition = $container->getDefinition('eight_points_guzzle.cookie_jar.test_api');
+        $this->assertSame(CookieJar::class, $cookieJarDefinition->getClass());
+        $this->assertTrue($cookieJarDefinition->hasTag('kernel.reset'));
+        $this->assertSame([['method' => 'clear']], $cookieJarDefinition->getTag('kernel.reset'));
+
+        $clientArgument = $container->getDefinition('eight_points_guzzle.client.test_api')->getArgument(0);
+        $this->assertArrayHasKey('cookies', $clientArgument);
+        $this->assertInstanceOf(Reference::class, $clientArgument['cookies']);
+        $this->assertSame('eight_points_guzzle.cookie_jar.test_api', (string) $clientArgument['cookies']);
+
+        $client = $container->get('eight_points_guzzle.client.test_api');
+        $this->assertInstanceOf(CookieJar::class, $client->getConfig('cookies'));
+    }
+
     public function testCompilation()
     {
         $container = $this->createContainer();

--- a/tests/Log/DevNullLoggerTest.php
+++ b/tests/Log/DevNullLoggerTest.php
@@ -3,6 +3,7 @@
 namespace EightPoints\Bundle\GuzzleBundle\Tests\Log;
 
 use EightPoints\Bundle\GuzzleBundle\Log\DevNullLogger;
+use Symfony\Contracts\Service\ResetInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 
@@ -33,4 +34,18 @@ class DevNullLoggerTest extends TestCase
         $this->assertFalse($logger->hasMessages());
         $this->assertCount(0, $logger->getMessages());
     }
+
+    /**
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\DevNullLogger::reset
+     */
+    public function testReset()
+    {
+        $logger = new DevNullLogger();
+        $logger->log('error', 'test message');
+        $logger->reset();
+        $this->assertFalse($logger->hasMessages());
+        $this->assertInstanceOf(ResetInterface::class, $logger);
+    }
+
+
 }

--- a/tests/Log/LoggerTest.php
+++ b/tests/Log/LoggerTest.php
@@ -5,6 +5,7 @@ namespace EightPoints\Bundle\GuzzleBundle\Tests\Log;
 use EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundle;
 use EightPoints\Bundle\GuzzleBundle\Log\Logger;
 use EightPoints\Bundle\GuzzleBundle\Log\LoggerInterface;
+use Symfony\Contracts\Service\ResetInterface;
 use EightPoints\Bundle\GuzzleBundle\Log\LogMessage;
 use EightPoints\Bundle\GuzzleBundle\Log\LogRequest;
 use EightPoints\Bundle\GuzzleBundle\Log\LogResponse;
@@ -22,7 +23,9 @@ class LoggerTest extends TestCase
      */
     public function testConstruct()
     {
-        $this->assertInstanceOf(LoggerInterface::class, new Logger());
+        $logger = new Logger();
+        $this->assertInstanceOf(LoggerInterface::class, $logger);
+        $this->assertInstanceOf(ResetInterface::class, $logger);
     }
 
     /**
@@ -117,6 +120,23 @@ class LoggerTest extends TestCase
         $this->assertCount(0, $logger->getMessages());
         $this->assertFalse($logger->hasMessages());
     }
+
+
+    /**
+     * Test Reset (Symfony ResetInterface / FrankenPHP worker)
+     *
+     * @covers \EightPoints\Bundle\GuzzleBundle\Log\Logger::reset
+     */
+    public function testReset()
+    {
+        $logger = new Logger();
+        $logger->log(LogLevel::ERROR, 'test message');
+        $this->assertTrue($logger->hasMessages());
+
+        $logger->reset();
+        $this->assertFalse($logger->hasMessages());
+    }
+
 
     public function getLoggerRequestModes()
     {


### PR DESCRIPTION
This pull request ensures **EightPointsGuzzleBundle** is safe to use in long-running PHP workers such as [FrankenPHP](https://frankenphp.dev/) worker mode (and similar runtimes where the Symfony container survives across HTTP requests).

Without proper service reset, singleton Guzzle clients and in-memory loggers can leak state between requests—leading to unbounded memory growth and unintended cookie sharing.

| Q             | A   |
| ------------- | --- |
| Bug fix       | yes |
| New feature   | no  |
| BC breaks     | no  |
| Deprecations  | no  |
| Tests pass    | yes |
| Fixed tickets | —   |
| License       | MIT |

## Motivation

In FrankenPHP worker mode, the PHP process and the service container remain alive between requests. Symfony relies on services tagged with `kernel.reset` to clear request-scoped state.

Prior to this change:

- The in-memory `Logger` accumulated messages (including request/response bodies) and was only cleared during profiler `collect()`.
- `HttpDataCollector::reset()` did not clear attached loggers, so `kernel.reset` without `collect()` left buffers intact.
- With `options.cookies: true`, Guzzle kept a `CookieJar` on the singleton client, allowing cookies to leak across unrelated Symfony requests.

## Changes

### Logging & profiler

- `Logger` and `DevNullLogger` implement `Symfony\Contracts\Service\ResetInterface`.
- Logger services are tagged with `kernel.reset` (`method: reset`).
- `HttpDataCollector::reset()` also clears attached loggers, covering the case where reset runs without `collect()`.

### Cookies

- When `options.cookies: true`, the extension injects a dedicated `GuzzleHttp\Cookie\CookieJar` service.
- That jar is tagged with `kernel.reset` (`method: clear`), so cookies are wiped between requests.

### Documentation

- Added [frankenphp-worker-mode.md](src/Resources/doc/frankenphp-worker-mode.md).
- Linked from `README.md` and noted in `UPGRADE.md` (no BC break).

## Backward compatibility

Fully backward compatible. No public API changes are required for consuming applications.

- Existing configurations continue to work as before.
- `cookies: true` remains supported and becomes worker-safe.
- Reset behavior is transparent under Symfony’s standard request lifecycle.

## Testing

- [x] Unit tests updated/added for `Logger::reset`, `DevNullLogger::reset`, collector reset without `collect()`, `kernel.reset` tags, and resettable cookie jars.
- [x] Full PHPUnit suite: **158 tests, 481 assertions** — all passing.
- [ ] CI matrix (PHP × Symfony) on this branch.
- [ ] Optional smoke test under FrankenPHP worker: enable logging, issue N requests, confirm stable memory and no cross-request cookie leakage.

## Checklist for reviewers

- [ ] Confirm `kernel.reset` tags on logger and cookie jar definitions.
- [ ] Confirm no BC impact for apps that do not use workers.
- [ ] Confirm documentation accuracy for production recommendations (`logging` / `profiling` tied to `%kernel.debug%`).